### PR TITLE
feat: add English/Chinese i18n and relative asset paths

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -73,8 +73,10 @@ jobs:
 
       - name: Check browser scripts
         run: |
+          node --check assets/js/i18n.js
           node --check assets/js/main.js
           node --check assets/js/mtr-agg.js
+          node --check assets/js/paths.js
           node --check assets/js/settingsmenu.js
           node --check assets/js/ui-state.js
           node --check tests/browser-harness.cjs

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ map $http_upgrade $connection_upgrade {
 
 # In the server block. https://example.com/tools/nexttrace/ maps to the container root:
 location = /tools/nexttrace {
-    return 301 /tools/nexttrace/;
+    return 301 /tools/nexttrace/$is_args$args;
 }
 
 location /tools/nexttrace/ {

--- a/README.md
+++ b/README.md
@@ -65,6 +65,39 @@ docker run --network host -d --privileged --name ntwa tsosc/nexttraceweb 80
 docker run --network host -d --privileged --name ntwa tsosc/nexttraceweb [::1]:30080
 ```
 
+## Interface Language
+
+The UI ships English and Simplified Chinese. The selector in the page header defaults to **Auto**, which follows the browser's `Accept-Language` preference; pick `English` or `中文` to pin one. The choice is stored in `localStorage` under `uiLanguage`.
+
+The separate **Geo Data Language** option inside the settings drawer is unrelated — it is passed straight to `nexttrace` and controls the language of geolocation data, not the interface.
+
+## Sub-path Deployment
+
+All assets, the `/api/devices` endpoint, and the Socket.IO path are resolved relative to the page's own directory, so the app can be mounted under a sub-path. The outer proxy must **strip the prefix** (note the trailing slash on both `location` and `proxy_pass`) and redirect the prefix without a trailing slash:
+
+```nginx
+# In the http block. $connection_upgrade is not a built-in variable:
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+# In the server block. https://example.com/tools/nexttrace/ maps to the container root:
+location = /tools/nexttrace {
+    return 301 /tools/nexttrace/;
+}
+
+location /tools/nexttrace/ {
+    proxy_http_version 1.1;
+    proxy_set_header Host $http_host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_pass http://127.0.0.1:30080/;
+}
+```
+
+Both trailing slashes matter. Drop the one on `proxy_pass` and the backend receives `/tools/nexttrace/...`, for which it has no route. The 301 covers visitors who leave the trailing slash out of the address bar: the browser resolves relative references against the parent directory, so the assets would be fetched from `/tools/assets/...` and the page would render unstyled.
+
 ## Runtime Notes
 
 - Health endpoint: `GET /healthz`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,6 +49,39 @@ docker run --network host -d --privileged --name ntwa tsosc/nexttraceweb [::1]:3
 
 建议不要直接把服务裸露在公网，认证和访问控制请放在外层反代或网关上处理。
 
+## 界面语言
+
+界面已支持英文和简体中文。页头的语言选择器默认为 **跟随系统**，即按浏览器的 `Accept-Language` 自动选择；也可以固定为 `English` 或 `中文`。选择结果保存在 `localStorage` 的 `uiLanguage` 中。
+
+设置抽屉里的 **地理数据语言** 是另一回事——它会直接传给 `nexttrace`，只影响地理位置数据的语言，不影响界面语言。
+
+## 二级路径部署
+
+静态资源、`/api/devices` 接口以及 Socket.IO 的路径都基于当前页面所在目录做相对解析，因此可以部署在二级路径下。外层反代需要**剥离路径前缀**（注意 `location` 和 `proxy_pass` 都要带结尾斜杠），并为不带结尾斜杠的地址加上跳转：
+
+```nginx
+# 放在 http 块中，$connection_upgrade 不是 nginx 内置变量：
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+# 放在 server 块中，把 https://example.com/tools/nexttrace/ 映射到容器根路径：
+location = /tools/nexttrace {
+    return 301 /tools/nexttrace/;
+}
+
+location /tools/nexttrace/ {
+    proxy_http_version 1.1;
+    proxy_set_header Host $http_host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_pass http://127.0.0.1:30080/;
+}
+```
+
+两处结尾斜杠都很关键。漏掉 `proxy_pass` 上的那个，后端就会收到 `/tools/nexttrace/...`，没有对应路由。那条 301 用于兜住地址栏里漏掉结尾斜杠的用户：此时浏览器会把相对引用解析到上一级目录，资源会被请求到 `/tools/assets/...`，页面会失去样式。
+
 ## 运行时说明
 
 - 健康检查接口：`GET /healthz`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,7 +68,7 @@ map $http_upgrade $connection_upgrade {
 
 # 放在 server 块中，把 https://example.com/tools/nexttrace/ 映射到容器根路径：
 location = /tools/nexttrace {
-    return 301 /tools/nexttrace/;
+    return 301 /tools/nexttrace/$is_args$args;
 }
 
 location /tools/nexttrace/ {

--- a/assets/css/m.css
+++ b/assets/css/m.css
@@ -2,7 +2,7 @@
     font-family: 'Roboto Mono';
     font-style: normal;
     font-weight: 400;
-    src: url(/assets/font/roboto-mono-latin.woff2) format('woff2');
+    src: url(../font/roboto-mono-latin.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -81,13 +81,31 @@ a {
 }
 
 .app-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 16px;
     margin-bottom: 18px;
 }
 
 .brand-copy {
     display: grid;
     gap: 8px;
+    flex: 1 1 420px;
+    min-width: 0;
     max-width: 900px;
+}
+
+.header-tools {
+    display: flex;
+    align-items: flex-end;
+    gap: 12px;
+    flex: 0 0 auto;
+}
+
+.field-language {
+    min-width: 148px;
 }
 
 .eyebrow {
@@ -708,6 +726,11 @@ body.settings-open {
     .results-panel,
     .helper-card {
         padding: 16px;
+    }
+
+    .header-tools,
+    .field-language {
+        width: 100%;
     }
 
     .control-row {

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -1,0 +1,448 @@
+(function (root, factory) {
+    var api = factory();
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+    if (root) {
+        root.nextTraceI18n = api;
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    var DEFAULT_LOCALE = 'en';
+    var SUPPORTED_LOCALES = ['en', 'zh'];
+    var AUTO_PREFERENCE = 'auto';
+    var SUPPORTED_PREFERENCES = [AUTO_PREFERENCE].concat(SUPPORTED_LOCALES);
+    var LOCALE_HTML_LANG = {
+        en: 'en',
+        zh: 'zh-CN'
+    };
+    var TABLE_HEADER_KEYS = [
+        'table.header.hop',
+        'table.header.ip',
+        'table.header.asn',
+        'table.header.location',
+        'table.header.owner',
+        'table.header.loss',
+        'table.header.sent',
+        'table.header.last',
+        'table.header.avg',
+        'table.header.best',
+        'table.header.worst',
+        'table.header.stdev',
+        'table.header.ptr'
+    ];
+    var ATTRIBUTE_BINDINGS = [
+        { attribute: 'placeholder', markup: 'data-i18n-placeholder' },
+        { attribute: 'aria-label', markup: 'data-i18n-aria-label' },
+        { attribute: 'title', markup: 'data-i18n-title' }
+    ];
+
+    var DICTIONARIES = {
+        en: {
+            'app.title': 'NextTrace Web',
+
+            'header.eyebrow': 'ping.pe inspired traceroute surface',
+            'header.tagline': 'Stream hop-by-hop route data with a denser layout, clearer state feedback, and faster repeat workflows.',
+            'header.language': 'Interface',
+            'language.auto': 'Auto',
+
+            'form.target.label': 'Target',
+            'form.target.placeholder': 'IP / domain / URL',
+            'form.ipVersion.label': 'IP Version',
+            'form.protocol.label': 'Protocol',
+
+            'action.start': 'Start',
+            'action.stop': 'Stop',
+            'action.reset': 'Reset',
+            'action.settings': 'Settings',
+            'action.share': 'Copy Share Link',
+            'action.shareCopied': 'Link Copied',
+
+            'status.fact.target': 'Target',
+            'status.fact.connection': 'Connection',
+            'status.fact.resolve': 'Resolve',
+            'status.fact.settings': 'Settings',
+
+            'state.idle.label': 'Idle',
+            'state.idle.detail': 'Ready for a new trace.',
+            'state.resolving.label': 'Resolving',
+            'state.resolving.detail': 'Resolving the target before starting the trace.',
+            'state.waiting.label': 'Waiting',
+            'state.waiting.detail': 'Trace started. Waiting for the first hop.',
+            'state.running.label': 'Running',
+            'state.running.detail': 'Streaming hop data in real time.',
+            'state.complete.label': 'Complete',
+            'state.complete.detail': 'Trace finished. Results are retained until you reset.',
+            'state.complete.detailEmpty': 'Trace finished without any hop data.',
+            'state.error.label': 'Error',
+            'state.error.detail': 'The trace ended with an error. Current results are retained.',
+            'state.error.detailEmpty': 'The trace could not be started. Adjust the target or settings.',
+            'state.disconnected.label': 'Disconnected',
+            'state.disconnected.detail': 'Connection lost. Current results stay on screen.',
+            'state.disconnected.detailEmpty': 'Connection lost. Reconnect before starting a new trace.',
+
+            'empty.idle.title': 'Ready for a new trace',
+            'empty.idle.description': 'Enter an IP, domain, or URL to start streaming hop data.',
+            'empty.resolving.title': 'Resolving target',
+            'empty.resolving.description': 'Checking the target and resolving DNS before the trace starts.',
+            'empty.waiting.title': 'Waiting for first hop',
+            'empty.waiting.description': 'The trace is running. Results will appear here as soon as the first hop arrives.',
+            'empty.complete.title': 'Trace finished',
+            'empty.complete.description': 'The task completed, but no hop data was captured.',
+            'empty.error.title': 'Trace failed',
+            'empty.error.description': 'Adjust the target or settings, then try again.',
+            'empty.disconnected.title': 'Disconnected',
+            'empty.disconnected.description': 'The trace service is unreachable. Reconnect and start again when the session returns.',
+
+            'connection.connecting': 'Connecting',
+            'connection.connected': 'Connected',
+            'connection.disconnected': 'Disconnected',
+
+            'target.notSet': 'Not set',
+
+            'summary.resolve.local': 'Local Resolve',
+            'summary.resolve.server': 'Server Resolve',
+
+            'results.eyebrow': 'trace state',
+            'table.eyebrow': 'streaming hop view',
+            'table.title': 'Trace Output',
+            'table.hint': 'Sticky header, horizontal scroll on narrow screens, raw TTL aggregation unchanged.',
+
+            'table.header.hop': 'HOP',
+            'table.header.ip': 'IP',
+            'table.header.asn': 'ASN',
+            'table.header.location': 'LOCATION',
+            'table.header.owner': 'OWNER',
+            'table.header.loss': 'LOSS%',
+            'table.header.sent': 'SENT',
+            'table.header.last': 'LAST',
+            'table.header.avg': 'AVG',
+            'table.header.best': 'BEST',
+            'table.header.worst': 'WORST',
+            'table.header.stdev': 'STDEV',
+            'table.header.ptr': 'PTR',
+
+            'panel.history.eyebrow': 'history',
+            'panel.history.title': 'Recent Queries',
+            'panel.history.meta': 'stored locally',
+            'panel.history.empty': 'Your recent traces will appear here.',
+            'panel.examples.eyebrow': 'quick start',
+            'panel.examples.title': 'Example Targets',
+            'panel.settings.eyebrow': 'effective configuration',
+            'panel.settings.title': 'Current Settings',
+
+            'settings.eyebrow': 'runtime settings',
+            'settings.title': 'Trace Settings',
+            'settings.close': 'Close settings',
+            'settings.language.label': 'Geo Data Language',
+            'settings.language.zh': 'Chinese',
+            'settings.language.en': 'English',
+            'settings.resolve.label': 'Resolve Mode',
+            'settings.resolve.hint': 'Prefer local DoH resolve before starting the trace',
+            'settings.interval.label': 'Probe Interval Seconds',
+            'settings.packetSize.label': 'Packet Size',
+            'settings.maxHop.label': 'Max Hop',
+            'settings.minHop.label': 'Min Hop',
+            'settings.port.label': 'Port',
+            'settings.device.label': 'Device',
+            'settings.device.placeholder': 'Device',
+            'settings.device.error': 'Invalid device name.',
+            'settings.dataProvider.label': 'Geo Data Provider',
+            'settings.dataProvider.placeholder': 'dataProvider',
+            'settings.dataProvider.error': 'Invalid data provider.',
+            'settings.save': 'Save Settings',
+
+            'modal.ipSelector.eyebrow': 'resolver result',
+            'modal.ipSelector.title': 'Choose a resolved IP',
+            'modal.close': 'Close selector',
+
+            'notice.connectionRestored': 'Connection restored. Start a new trace when ready.',
+            'notice.connectionLost': 'Connection to the trace service was lost. Current results stay on screen.',
+            'notice.selectionCancelled': 'Target selection cancelled.',
+            'notice.emptyTarget': 'Enter an IP, domain, or URL before starting a trace.',
+            'notice.unresolvable': 'Invalid input or unresolvable domain. Adjust the target or switch resolve mode.',
+            'notice.stopped': 'Trace stopped. Current results are retained.',
+            'notice.shareCopied': 'Share link copied to clipboard.',
+            'notice.shareFailed': 'Copy failed. You can still copy the current URL manually.',
+
+            'error.taskFailed': 'The trace task failed.',
+
+            'serverError.invalid_payload': 'The server rejected one of the trace settings. Review the values in the settings drawer.',
+            'serverError.invalid_target': 'The server rejected the target address. Check the IP, domain, or URL you entered.',
+            'serverError.start_failed': 'The server could not start nexttrace. Check the server configuration.',
+            'serverError.trace_capacity_exceeded': 'The server reached its concurrent trace limit. Try again shortly.',
+            'serverError.trace_idle_timeout': 'The trace produced no output for too long and was stopped.',
+            'serverError.trace_max_duration_reached': 'The trace reached its maximum run time and was stopped.',
+            'serverError.trace_not_running': 'There is no running trace to interact with.',
+            'serverError.trace_rate_limited': 'Too many requests. Wait a moment and try again.'
+        },
+        zh: {
+            'app.title': 'NextTrace Web',
+
+            'header.eyebrow': '受 ping.pe 启发的路由追踪界面',
+            'header.tagline': '以更紧凑的布局、更清晰的状态反馈和更快的重复查询流程，逐跳流式呈现路由数据。',
+            'header.language': '界面语言',
+            'language.auto': '跟随系统',
+
+            'form.target.label': '目标',
+            'form.target.placeholder': 'IP / 域名 / URL',
+            'form.ipVersion.label': 'IP 版本',
+            'form.protocol.label': '协议',
+
+            'action.start': '开始',
+            'action.stop': '停止',
+            'action.reset': '重置',
+            'action.settings': '设置',
+            'action.share': '复制分享链接',
+            'action.shareCopied': '已复制链接',
+
+            'status.fact.target': '目标',
+            'status.fact.connection': '连接',
+            'status.fact.resolve': '解析',
+            'status.fact.settings': '设置',
+
+            'state.idle.label': '空闲',
+            'state.idle.detail': '已就绪，可以开始新的追踪。',
+            'state.resolving.label': '解析中',
+            'state.resolving.detail': '正在解析目标，随后开始追踪。',
+            'state.waiting.label': '等待中',
+            'state.waiting.detail': '追踪已启动，正在等待第一跳。',
+            'state.running.label': '运行中',
+            'state.running.detail': '正在实时接收逐跳数据。',
+            'state.complete.label': '已完成',
+            'state.complete.detail': '追踪已结束，结果会保留至你重置。',
+            'state.complete.detailEmpty': '追踪已结束，但没有获得任何跳数据。',
+            'state.error.label': '出错',
+            'state.error.detail': '追踪因错误结束，当前结果已保留。',
+            'state.error.detailEmpty': '追踪未能启动，请调整目标或设置。',
+            'state.disconnected.label': '已断开',
+            'state.disconnected.detail': '连接已断开，当前结果仍保留在页面上。',
+            'state.disconnected.detailEmpty': '连接已断开，请重新连接后再开始追踪。',
+
+            'empty.idle.title': '已就绪，可以开始新的追踪',
+            'empty.idle.description': '输入 IP、域名或 URL 即可开始接收逐跳数据。',
+            'empty.resolving.title': '正在解析目标',
+            'empty.resolving.description': '正在校验目标并解析 DNS，随后开始追踪。',
+            'empty.waiting.title': '正在等待第一跳',
+            'empty.waiting.description': '追踪正在进行，第一跳到达后结果会显示在这里。',
+            'empty.complete.title': '追踪已结束',
+            'empty.complete.description': '任务已完成，但没有捕获到任何跳数据。',
+            'empty.error.title': '追踪失败',
+            'empty.error.description': '请调整目标或设置后重试。',
+            'empty.disconnected.title': '连接已断开',
+            'empty.disconnected.description': '追踪服务当前不可用，连接恢复后请重新开始。',
+
+            'connection.connecting': '连接中',
+            'connection.connected': '已连接',
+            'connection.disconnected': '已断开',
+
+            'target.notSet': '未设置',
+
+            'summary.resolve.local': '本地解析',
+            'summary.resolve.server': '服务端解析',
+
+            'results.eyebrow': '追踪状态',
+            'table.eyebrow': '实时逐跳视图',
+            'table.title': '追踪结果',
+            'table.hint': '表头吸顶，窄屏可横向滚动，原始 TTL 聚合逻辑保持不变。',
+
+            'table.header.hop': '跳数',
+            'table.header.ip': 'IP',
+            'table.header.asn': 'ASN',
+            'table.header.location': '地理位置',
+            'table.header.owner': '归属',
+            'table.header.loss': '丢包率',
+            'table.header.sent': '发送',
+            'table.header.last': '最新',
+            'table.header.avg': '平均',
+            'table.header.best': '最优',
+            'table.header.worst': '最差',
+            'table.header.stdev': '标准差',
+            'table.header.ptr': 'PTR',
+
+            'panel.history.eyebrow': '历史记录',
+            'panel.history.title': '最近查询',
+            'panel.history.meta': '保存在本地',
+            'panel.history.empty': '最近的追踪记录会显示在这里。',
+            'panel.examples.eyebrow': '快速开始',
+            'panel.examples.title': '示例目标',
+            'panel.settings.eyebrow': '当前生效配置',
+            'panel.settings.title': '当前设置',
+
+            'settings.eyebrow': '运行参数',
+            'settings.title': '追踪设置',
+            'settings.close': '关闭设置',
+            'settings.language.label': '地理数据语言',
+            'settings.language.zh': '中文',
+            'settings.language.en': '英文',
+            'settings.resolve.label': '解析模式',
+            'settings.resolve.hint': '启动追踪前优先使用本地 DoH 解析',
+            'settings.interval.label': '探测间隔（秒）',
+            'settings.packetSize.label': '数据包大小',
+            'settings.maxHop.label': '最大跳数',
+            'settings.minHop.label': '最小跳数',
+            'settings.port.label': '端口',
+            'settings.device.label': '网络接口',
+            'settings.device.placeholder': '网络接口',
+            'settings.device.error': '网络接口名称无效。',
+            'settings.dataProvider.label': 'IP 数据源',
+            'settings.dataProvider.placeholder': 'dataProvider',
+            'settings.dataProvider.error': 'IP 数据源无效。',
+            'settings.save': '保存设置',
+
+            'modal.ipSelector.eyebrow': '解析结果',
+            'modal.ipSelector.title': '请选择一个 IP 地址',
+            'modal.close': '关闭选择器',
+
+            'notice.connectionRestored': '连接已恢复，可随时开始新的追踪。',
+            'notice.connectionLost': '与追踪服务的连接已断开，当前结果仍保留在页面上。',
+            'notice.selectionCancelled': '已取消目标选择。',
+            'notice.emptyTarget': '请先输入 IP、域名或 URL，然后再开始追踪。',
+            'notice.unresolvable': '输入无效或域名无法解析，请调整目标或切换解析模式。',
+            'notice.stopped': '追踪已停止，当前结果已保留。',
+            'notice.shareCopied': '分享链接已复制到剪贴板。',
+            'notice.shareFailed': '复制失败，你仍可手动复制当前地址。',
+
+            'error.taskFailed': '任务执行失败。',
+
+            'serverError.invalid_payload': '服务端拒绝了某项追踪设置，请检查设置面板中的取值。',
+            'serverError.invalid_target': '服务端拒绝了目标地址，请检查填写的 IP、域名或 URL。',
+            'serverError.start_failed': '服务端启动 nexttrace 失败，请检查服务器配置。',
+            'serverError.trace_capacity_exceeded': '当前并发任务已达上限，请稍后再试。',
+            'serverError.trace_idle_timeout': '任务长时间无输出，已停止。',
+            'serverError.trace_max_duration_reached': '任务达到最大运行时长，已停止。',
+            'serverError.trace_not_running': '当前没有正在运行的 trace 任务。',
+            'serverError.trace_rate_limited': '操作过于频繁，请稍后再试。'
+        }
+    };
+
+    function normalizeLocale(value) {
+        if (typeof value !== 'string') {
+            return null;
+        }
+
+        var normalized = value.trim().toLowerCase().replace(/_/g, '-');
+        if (normalized === '') {
+            return null;
+        }
+        if (normalized === 'cn' || normalized === 'zh' || normalized.indexOf('zh-') === 0) {
+            return 'zh';
+        }
+        if (normalized === 'en' || normalized.indexOf('en-') === 0) {
+            return 'en';
+        }
+        return null;
+    }
+
+    function normalizePreference(value) {
+        if (typeof value === 'string' && value.trim().toLowerCase() === AUTO_PREFERENCE) {
+            return AUTO_PREFERENCE;
+        }
+        return normalizeLocale(value) || AUTO_PREFERENCE;
+    }
+
+    // An explicit 'en'/'zh' preference wins; 'auto' (the default) falls through to
+    // the browser language candidates, then to DEFAULT_LOCALE.
+    function detectLocale(storedValue, candidates) {
+        var storedLocale = normalizeLocale(storedValue);
+        if (storedLocale) {
+            return storedLocale;
+        }
+
+        var candidateList = Array.isArray(candidates) ? candidates : [candidates];
+        for (var index = 0; index < candidateList.length; index += 1) {
+            var candidateLocale = normalizeLocale(candidateList[index]);
+            if (candidateLocale) {
+                return candidateLocale;
+            }
+        }
+
+        return DEFAULT_LOCALE;
+    }
+
+    function getDictionary(locale) {
+        return DICTIONARIES[normalizeLocale(locale) || DEFAULT_LOCALE];
+    }
+
+    function translate(locale, key) {
+        if (typeof key !== 'string' || key === '') {
+            return '';
+        }
+
+        var dictionary = getDictionary(locale);
+        if (Object.prototype.hasOwnProperty.call(dictionary, key)) {
+            return dictionary[key];
+        }
+
+        var fallbackDictionary = DICTIONARIES[DEFAULT_LOCALE];
+        if (Object.prototype.hasOwnProperty.call(fallbackDictionary, key)) {
+            return fallbackDictionary[key];
+        }
+
+        return key;
+    }
+
+    function createTranslator(locale) {
+        return function (key) {
+            return translate(locale, key);
+        };
+    }
+
+    function getTableHeaderLabels(locale) {
+        return TABLE_HEADER_KEYS.map(function (key) {
+            return translate(locale, key);
+        });
+    }
+
+    function getHtmlLang(locale) {
+        var resolvedLocale = normalizeLocale(locale) || DEFAULT_LOCALE;
+        return LOCALE_HTML_LANG[resolvedLocale];
+    }
+
+    function applyDocumentTranslations(documentRef, locale) {
+        if (!documentRef || typeof documentRef.querySelectorAll !== 'function') {
+            return 0;
+        }
+
+        var appliedCount = 0;
+
+        documentRef.querySelectorAll('[data-i18n]').forEach(function (element) {
+            element.textContent = translate(locale, element.getAttribute('data-i18n'));
+            appliedCount += 1;
+        });
+
+        ATTRIBUTE_BINDINGS.forEach(function (binding) {
+            documentRef.querySelectorAll('[' + binding.markup + ']').forEach(function (element) {
+                element.setAttribute(binding.attribute, translate(locale, element.getAttribute(binding.markup)));
+                appliedCount += 1;
+            });
+        });
+
+        if (documentRef.documentElement && typeof documentRef.documentElement.setAttribute === 'function') {
+            documentRef.documentElement.setAttribute('lang', getHtmlLang(locale));
+        }
+
+        return appliedCount;
+    }
+
+    function listKeys(locale) {
+        return Object.keys(getDictionary(locale));
+    }
+
+    return {
+        AUTO_PREFERENCE: AUTO_PREFERENCE,
+        DEFAULT_LOCALE: DEFAULT_LOCALE,
+        SUPPORTED_LOCALES: SUPPORTED_LOCALES,
+        SUPPORTED_PREFERENCES: SUPPORTED_PREFERENCES,
+        TABLE_HEADER_KEYS: TABLE_HEADER_KEYS,
+        applyDocumentTranslations: applyDocumentTranslations,
+        createTranslator: createTranslator,
+        detectLocale: detectLocale,
+        getDictionary: getDictionary,
+        getHtmlLang: getHtmlLang,
+        getTableHeaderLabels: getTableHeaderLabels,
+        listKeys: listKeys,
+        normalizeLocale: normalizeLocale,
+        normalizePreference: normalizePreference,
+        translate: translate
+    };
+});

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -25,6 +25,11 @@ var LOCALIZED_SERVER_ERROR_CODES = [
     'trace_not_running',
     'trace_rate_limited'
 ];
+var SERVER_ERROR_CODES_WITH_DETAILS = [
+    'invalid_payload',
+    'invalid_target',
+    'trace_not_running'
+];
 
 var uiState = {
     connectionStatus: 'connecting',
@@ -129,7 +134,7 @@ socket.on('nexttrace_error', function (data) {
     traceViewState.acceptUpdates = false;
     uiState.taskStatus = 'error';
     if (noticeKey !== '') {
-        setNotice(noticeKey, 'error');
+        setNotice(noticeKey, 'error', shouldShowServerErrorDetail(data) ? serverMessage : '');
     } else if (serverMessage !== '') {
         setNoticeText(serverMessage, 'error');
     } else {
@@ -371,7 +376,11 @@ function renderStatusSummary() {
 
 function renderNotice() {
     var notice = $('noticeBanner');
-    var message = uiState.noticeKey !== '' ? t(uiState.noticeKey) : uiState.noticeMessage;
+    var message = uiState.noticeKey !== '' ? t(uiState.noticeKey) : '';
+
+    if (uiState.noticeMessage !== '') {
+        message = message !== '' ? message + ' — ' + uiState.noticeMessage : uiState.noticeMessage;
+    }
 
     if (!message) {
         notice.hidden = true;
@@ -591,11 +600,11 @@ function hideSelectionModal(triggerCancel) {
     modalCancelHandler = null;
 }
 
-// Notices keep a translation key so they follow a language switch. Server-provided
-// messages have no key and are shown verbatim through setNoticeText.
-function setNotice(messageKey, tone) {
+// Notices keep a translation key so they follow a language switch. A server-provided
+// detail can be retained verbatim alongside the localized summary.
+function setNotice(messageKey, tone, detailMessage) {
     uiState.noticeKey = messageKey || '';
-    uiState.noticeMessage = '';
+    uiState.noticeMessage = detailMessage || '';
     uiState.noticeTone = tone || 'info';
     renderNotice();
 }
@@ -614,15 +623,19 @@ function clearNotice() {
     renderNotice();
 }
 
-// Codes whose server message is a fixed sentence get localized copy instead. The
-// remaining codes (nexttrace_exit_nonzero, nexttrace_invalid_args) carry nexttrace's own
-// diagnostic output in `message`, which is shown verbatim.
+// Known codes get a localized summary. Parameter-specific validation codes retain their
+// server detail; nexttrace_exit_nonzero and nexttrace_invalid_args remain verbatim.
 function getServerErrorKey(data) {
     var code = data && typeof data.code === 'string' ? data.code : '';
     if (code === '') {
         return '';
     }
     return LOCALIZED_SERVER_ERROR_CODES.indexOf(code) === -1 ? '' : 'serverError.' + code;
+}
+
+function shouldShowServerErrorDetail(data) {
+    var code = data && typeof data.code === 'string' ? data.code : '';
+    return SERVER_ERROR_CODES_WITH_DETAILS.indexOf(code) !== -1;
 }
 
 function getServerErrorMessage(data) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -288,7 +288,11 @@ function stopNexttrace() {
     clearScheduledRender();
     hideSelectionModal(false);
     uiState.taskStatus = uiState.rowsRendered > 0 ? 'complete' : 'idle';
-    setNotice(uiState.rowsRendered > 0 ? 'notice.stopped' : '', 'info');
+    if (uiState.rowsRendered > 0) {
+        setNotice('notice.stopped', 'info');
+    } else {
+        clearNotice();
+    }
     renderUi();
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,13 +1,30 @@
-var socket = io.connect(location.origin);
 var mtrAggApi = window.nextTraceMTRAgg;
 var uiStateApi = window.nextTraceUIState;
+var i18nApi = window.nextTraceI18n;
+var pathsApi = window.nextTracePaths;
+var socket = io.connect(location.origin, {
+    path: pathsApi.joinBasePath(location.pathname, 'socket.io')
+});
 var mtrAggregator = mtrAggApi.createMTRAggregator();
 var traceViewState = mtrAggApi.createTraceViewState();
 var renderTimer = null;
 var shareTimer = null;
 var modalCancelHandler = null;
+var activeLocale = i18nApi.DEFAULT_LOCALE;
+var tableHeaderHtml = mtrAggApi.TABLE_HEADER_HTML;
 var MTR_RENDER_INTERVAL_MS = 100;
 var RECENT_QUERIES_STORAGE_KEY = 'ntwaRecentQueries';
+var UI_LANGUAGE_STORAGE_KEY = 'uiLanguage';
+var LOCALIZED_SERVER_ERROR_CODES = [
+    'invalid_payload',
+    'invalid_target',
+    'start_failed',
+    'trace_capacity_exceeded',
+    'trace_idle_timeout',
+    'trace_max_duration_reached',
+    'trace_not_running',
+    'trace_rate_limited'
+];
 
 var uiState = {
     connectionStatus: 'connecting',
@@ -15,6 +32,7 @@ var uiState = {
     requestedTarget: '',
     resolvedTarget: '',
     rowsRendered: 0,
+    noticeKey: '',
     noticeMessage: '',
     noticeTone: 'info',
     recentQueries: [],
@@ -25,12 +43,48 @@ function $(id) {
     return document.getElementById(id);
 }
 
+function t(key) {
+    return i18nApi.translate(activeLocale, key);
+}
+
+function getBrowserLanguages() {
+    if (typeof navigator === 'undefined' || !navigator) {
+        return [];
+    }
+    if (Array.isArray(navigator.languages) && navigator.languages.length > 0) {
+        return navigator.languages;
+    }
+    return [navigator.language];
+}
+
+// A stored 'auto' preference (the default) resolves through the browser languages.
+function resolveActiveLocale() {
+    return i18nApi.detectLocale(localStorage.getItem(UI_LANGUAGE_STORAGE_KEY), getBrowserLanguages());
+}
+
+function applyLocale(locale) {
+    activeLocale = locale;
+    tableHeaderHtml = mtrAggApi.buildTableHeaderHtml(i18nApi.getTableHeaderLabels(locale));
+    i18nApi.applyDocumentTranslations(document, locale);
+}
+
+function syncLanguageSelect() {
+    $('uiLanguage').value = i18nApi.normalizePreference(localStorage.getItem(UI_LANGUAGE_STORAGE_KEY));
+}
+
+function handleLanguageChange() {
+    localStorage.setItem(UI_LANGUAGE_STORAGE_KEY, i18nApi.normalizePreference($('uiLanguage').value));
+    applyLocale(resolveActiveLocale());
+    renderUi();
+    renderTable();
+}
+
 socket.on('connect', function () {
     console.log('Connected');
     uiState.connectionStatus = 'connected';
     if (uiState.taskStatus === 'disconnected') {
         uiState.taskStatus = uiState.rowsRendered > 0 ? 'complete' : 'idle';
-        setNotice('Connection restored. Start a new trace when ready.', 'info');
+        setNotice('notice.connectionRestored', 'info');
     }
     renderUi();
 });
@@ -43,7 +97,7 @@ socket.on('disconnect', function () {
     uiState.taskStatus = 'disconnected';
     hideSelectionModal(false);
     clearScheduledRender();
-    setNotice('Connection to the trace service was lost. Current results stay on screen.', 'error');
+    setNotice('notice.connectionLost', 'error');
     renderUi();
 });
 
@@ -70,25 +124,35 @@ socket.on('nexttrace_complete', function () {
 });
 
 socket.on('nexttrace_error', function (data) {
+    var noticeKey = getServerErrorKey(data);
+    var serverMessage = getServerErrorMessage(data);
     traceViewState.acceptUpdates = false;
     uiState.taskStatus = 'error';
-    setNotice(getErrorMessage(data), 'error');
+    if (noticeKey !== '') {
+        setNotice(noticeKey, 'error');
+    } else if (serverMessage !== '') {
+        setNoticeText(serverMessage, 'error');
+    } else {
+        setNotice('error.taskFailed', 'error');
+    }
     console.error('Nexttrace error:', data);
     renderUi();
 });
 
 socket.on('nexttrace_options', function (data) {
-    showSelectionModal('Choose a resolved IP', data, function (index) {
+    showSelectionModal(t('modal.ipSelector.title'), data, function (index) {
         socket.emit('nexttrace_options_choice', { choice: index + 1 });
     }, function () {
         traceViewState.acceptUpdates = false;
         uiState.taskStatus = 'idle';
-        setNotice('Target selection cancelled.', 'info');
+        setNotice('notice.selectionCancelled', 'info');
         renderUi();
     });
 });
 
 function initializePage() {
+    applyLocale(resolveActiveLocale());
+    syncLanguageSelect();
     uiState.recentQueries = uiStateApi.loadRecentQueries(localStorage.getItem(RECENT_QUERIES_STORAGE_KEY));
     restorePrimaryControls();
     bindPageEvents();
@@ -109,6 +173,7 @@ function bindPageEvents() {
     });
     $('ipVersion').addEventListener('change', persistPrimaryControlState);
     $('protocol').addEventListener('change', persistPrimaryControlState);
+    $('uiLanguage').addEventListener('change', handleLanguageChange);
     $('startBtn').addEventListener('click', function () {
         startNexttrace();
     });
@@ -184,7 +249,7 @@ async function startNexttrace() {
     var params = uiStateApi.normalizeQuery($('params').value);
     if (params === '') {
         uiState.taskStatus = 'error';
-        setNotice('Enter an IP, domain, or URL before starting a trace.', 'error');
+        setNotice('notice.emptyTarget', 'error');
         renderUi();
         return;
     }
@@ -203,7 +268,7 @@ async function startNexttrace() {
     if (resolvedTarget == null) {
         traceViewState.acceptUpdates = false;
         uiState.taskStatus = 'error';
-        setNotice('Invalid input or unresolvable domain. Adjust the target or switch resolve mode.', 'error');
+        setNotice('notice.unresolvable', 'error');
         renderUi();
         return;
     }
@@ -223,7 +288,7 @@ function stopNexttrace() {
     clearScheduledRender();
     hideSelectionModal(false);
     uiState.taskStatus = uiState.rowsRendered > 0 ? 'complete' : 'idle';
-    setNotice(uiState.rowsRendered > 0 ? 'Trace stopped. Current results are retained.' : '', 'info');
+    setNotice(uiState.rowsRendered > 0 ? 'notice.stopped' : '', 'info');
     renderUi();
 }
 
@@ -265,13 +330,13 @@ function scheduleTableRender() {
 function renderTable() {
     var rows = mtrAggApi.buildRenderableRows(mtrAggregator);
     uiState.rowsRendered = rows.length;
-    $('output').querySelector('tbody').innerHTML = mtrAggApi.renderTableHtml(rows);
+    $('output').querySelector('tbody').innerHTML = mtrAggApi.renderTableHtml(rows, tableHeaderHtml);
     renderStatusStrip();
     renderEmptyState();
 }
 
 function initTable() {
-    $('output').querySelector('tbody').innerHTML = mtrAggApi.TABLE_HEADER_HTML;
+    $('output').querySelector('tbody').innerHTML = tableHeaderHtml;
 }
 
 function renderUi() {
@@ -285,24 +350,26 @@ function renderUi() {
 
 function renderStatusStrip() {
     var meta = uiStateApi.deriveTaskMeta(uiState.taskStatus, uiState.connectionStatus, uiState.rowsRendered);
-    $('taskStatusBadge').textContent = meta.label;
+    $('taskStatusBadge').textContent = t(meta.labelKey);
     $('taskStatusBadge').setAttribute('data-tone', meta.tone);
-    $('taskStatusDetail').textContent = meta.detail;
-    $('targetSummary').textContent = uiStateApi.formatTargetSummary(uiState.requestedTarget, uiState.resolvedTarget);
-    $('connectionSummary').textContent = formatConnectionStatus(uiState.connectionStatus);
+    $('taskStatusDetail').textContent = t(meta.detailKey);
+    $('targetSummary').textContent = uiStateApi.formatTargetSummary(uiState.requestedTarget, uiState.resolvedTarget, t);
+    $('connectionSummary').textContent = t(uiStateApi.getConnectionStatusKey(uiState.connectionStatus));
     renderStatusSummary();
 }
 
 function renderStatusSummary() {
     var settings = readCurrentSettings();
-    var summary = uiStateApi.buildSettingsSummary(settings);
-    $('resolveModeSummary').textContent = uiStateApi.getResolveModeLabel(settings.localResolve);
+    var summary = uiStateApi.buildSettingsSummary(settings, t);
+    $('resolveModeSummary').textContent = t(uiStateApi.getResolveModeKey(settings.localResolve));
     $('settingsSummaryInline').textContent = summary.join(' · ');
 }
 
 function renderNotice() {
     var notice = $('noticeBanner');
-    if (!uiState.noticeMessage) {
+    var message = uiState.noticeKey !== '' ? t(uiState.noticeKey) : uiState.noticeMessage;
+
+    if (!message) {
         notice.hidden = true;
         notice.textContent = '';
         return;
@@ -310,7 +377,7 @@ function renderNotice() {
 
     notice.hidden = false;
     notice.setAttribute('data-tone', uiState.noticeTone || 'info');
-    notice.textContent = uiState.noticeMessage;
+    notice.textContent = message;
 }
 
 function renderEmptyState() {
@@ -323,8 +390,8 @@ function renderEmptyState() {
 
     panel.hidden = !emptyState.visible;
     panel.setAttribute('data-tone', emptyState.tone);
-    $('resultStateTitle').textContent = emptyState.title;
-    $('resultStateText').textContent = emptyState.description;
+    $('resultStateTitle').textContent = t(emptyState.titleKey);
+    $('resultStateText').textContent = t(emptyState.descriptionKey);
 }
 
 function renderRecentQueries() {
@@ -335,7 +402,7 @@ function renderRecentQueries() {
         container.classList.add('chip-list-empty');
         var emptyLabel = document.createElement('span');
         emptyLabel.className = 'helper-empty';
-        emptyLabel.textContent = 'Your recent traces will appear here.';
+        emptyLabel.textContent = t('panel.history.empty');
         container.appendChild(emptyLabel);
         return;
     }
@@ -357,7 +424,7 @@ function renderSettingsSummaryPanel() {
     var summaryItems = [
         $('ipVersion').value.toUpperCase(),
         $('protocol').value.toUpperCase()
-    ].concat(uiStateApi.buildSettingsSummary(settings));
+    ].concat(uiStateApi.buildSettingsSummary(settings, t));
 
     container.innerHTML = '';
     summaryItems.forEach(function (item) {
@@ -378,7 +445,7 @@ function renderActionButtons() {
     $('startBtn').disabled = actionState.startDisabled;
     $('stopBtn').disabled = actionState.stopDisabled;
     $('shareBtn').disabled = actionState.shareDisabled;
-    $('shareBtn').textContent = uiState.shareCopied ? 'Link Copied' : 'Copy Share Link';
+    $('shareBtn').textContent = uiState.shareCopied ? t('action.shareCopied') : t('action.share');
 }
 
 function syncTargetPreview() {
@@ -420,7 +487,7 @@ function copyShareLink() {
     copyTextToClipboard(shareUrl)
         .then(function () {
             uiState.shareCopied = true;
-            setNotice('Share link copied to clipboard.', 'success');
+            setNotice('notice.shareCopied', 'success');
             renderActionButtons();
             if (shareTimer !== null) {
                 clearTimeout(shareTimer);
@@ -431,7 +498,7 @@ function copyShareLink() {
             }, 1800);
         })
         .catch(function () {
-            setNotice('Copy failed. You can still copy the current URL manually.', 'error');
+            setNotice('notice.shareFailed', 'error');
         });
 }
 
@@ -520,26 +587,48 @@ function hideSelectionModal(triggerCancel) {
     modalCancelHandler = null;
 }
 
-function setNotice(message, tone) {
+// Notices keep a translation key so they follow a language switch. Server-provided
+// messages have no key and are shown verbatim through setNoticeText.
+function setNotice(messageKey, tone) {
+    uiState.noticeKey = messageKey || '';
+    uiState.noticeMessage = '';
+    uiState.noticeTone = tone || 'info';
+    renderNotice();
+}
+
+function setNoticeText(message, tone) {
+    uiState.noticeKey = '';
     uiState.noticeMessage = message || '';
     uiState.noticeTone = tone || 'info';
     renderNotice();
 }
 
 function clearNotice() {
+    uiState.noticeKey = '';
     uiState.noticeMessage = '';
     uiState.noticeTone = 'info';
     renderNotice();
 }
 
-function getErrorMessage(data) {
+// Codes whose server message is a fixed sentence get localized copy instead. The
+// remaining codes (nexttrace_exit_nonzero, nexttrace_invalid_args) carry nexttrace's own
+// diagnostic output in `message`, which is shown verbatim.
+function getServerErrorKey(data) {
+    var code = data && typeof data.code === 'string' ? data.code : '';
+    if (code === '') {
+        return '';
+    }
+    return LOCALIZED_SERVER_ERROR_CODES.indexOf(code) === -1 ? '' : 'serverError.' + code;
+}
+
+function getServerErrorMessage(data) {
     if (typeof data === 'string' && data.trim() !== '') {
         return data.trim();
     }
     if (data && typeof data.message === 'string' && data.message.trim() !== '') {
         return data.message.trim();
     }
-    return '任务执行失败';
+    return '';
 }
 
 function getValueFromLocalStorage(key) {
@@ -588,7 +677,9 @@ function fetchWithTimeout(url, options, timeout) {
         fetch(url, options),
         new Promise(function (_, reject) {
             setTimeout(function () {
-                reject(new Error('请求超时'));
+                // resolveDomain swallows this to fall through to the next DoH endpoint,
+                // so it never reaches the user and stays an untranslated diagnostic.
+                reject(new Error('doh request timeout'));
             }, timeout);
         })
     ]);
@@ -638,7 +729,7 @@ function resolveDomain(domain) {
             })
             .then(function () {
                 if (resolvedAddresses.length > 1) {
-                    showSelectionModal('Choose a resolved IP', resolvedAddresses, function (index) {
+                    showSelectionModal(t('modal.ipSelector.title'), resolvedAddresses, function (index) {
                         resolve(resolvedAddresses[index]);
                     }, function () {
                         resolve(null);
@@ -685,16 +776,6 @@ function parseDomain(domain) {
 
 function isIpLiteral(value) {
     return /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(value) || /^[a-fA-F0-9:]+$/.test(value);
-}
-
-function formatConnectionStatus(status) {
-    if (status === 'connected') {
-        return 'Connected';
-    }
-    if (status === 'disconnected') {
-        return 'Disconnected';
-    }
-    return 'Connecting';
 }
 
 function deviceValidateInput() {

--- a/assets/js/mtr-agg.js
+++ b/assets/js/mtr-agg.js
@@ -7,23 +7,33 @@
         root.nextTraceMTRAgg = api;
     }
 })(typeof globalThis !== 'undefined' ? globalThis : this, function () {
-    var TABLE_HEADER_HTML = [
-        '<tr>',
-        '<th>HOP</th>',
-        '<th>IP</th>',
-        '<th>ASN</th>',
-        '<th>LOCATION</th>',
-        '<th>OWNER</th>',
-        '<th>LOSS%</th>',
-        '<th>SENT</th>',
-        '<th>LAST</th>',
-        '<th>AVG</th>',
-        '<th>BEST</th>',
-        '<th>WORST</th>',
-        '<th>STDEV</th>',
-        '<th>PTR</th>',
-        '</tr>'
-    ].join('');
+    var DEFAULT_TABLE_HEADER_LABELS = [
+        'HOP',
+        'IP',
+        'ASN',
+        'LOCATION',
+        'OWNER',
+        'LOSS%',
+        'SENT',
+        'LAST',
+        'AVG',
+        'BEST',
+        'WORST',
+        'STDEV',
+        'PTR'
+    ];
+
+    function buildTableHeaderHtml(labels) {
+        var headerLabels = Array.isArray(labels) && labels.length === DEFAULT_TABLE_HEADER_LABELS.length
+            ? labels
+            : DEFAULT_TABLE_HEADER_LABELS;
+
+        return '<tr>' + headerLabels.map(function (label) {
+            return '<th>' + escapeHTML(String(label)) + '</th>';
+        }).join('') + '</tr>';
+    }
+
+    var TABLE_HEADER_HTML = buildTableHeaderHtml();
 
     function createMTRAggregator() {
         return {
@@ -177,8 +187,8 @@
         });
     }
 
-    function renderTableHtml(rows) {
-        var bodyHtml = TABLE_HEADER_HTML;
+    function renderTableHtml(rows, headerHtml) {
+        var bodyHtml = typeof headerHtml === 'string' && headerHtml !== '' ? headerHtml : TABLE_HEADER_HTML;
         (rows || []).forEach(function (row) {
             bodyHtml += renderRowHtml(row);
         });
@@ -380,6 +390,7 @@
         buildLossStyle: buildLossStyle,
         buildRenderableRows: buildRenderableRows,
         buildStdevStyle: buildStdevStyle,
+        buildTableHeaderHtml: buildTableHeaderHtml,
         cancelTraceIntent: cancelTraceIntent,
         createMTRAggregator: createMTRAggregator,
         createTraceViewState: createTraceViewState,

--- a/assets/js/paths.js
+++ b/assets/js/paths.js
@@ -1,0 +1,34 @@
+(function (root, factory) {
+    var api = factory();
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+    if (root) {
+        root.nextTracePaths = api;
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    function resolveBasePath(pathname) {
+        if (typeof pathname !== 'string' || pathname === '') {
+            return '/';
+        }
+
+        var boundary = pathname.search(/[?#]/);
+        var directoryPath = boundary === -1 ? pathname : pathname.slice(0, boundary);
+
+        if (directoryPath.charAt(0) !== '/') {
+            directoryPath = '/' + directoryPath;
+        }
+
+        return directoryPath.replace(/[^/]*$/, '');
+    }
+
+    function joinBasePath(pathname, relativePath) {
+        var suffix = typeof relativePath === 'string' ? relativePath.replace(/^\/+/, '') : '';
+        return resolveBasePath(pathname) + suffix;
+    }
+
+    return {
+        joinBasePath: joinBasePath,
+        resolveBasePath: resolveBasePath
+    };
+});

--- a/assets/js/settingsmenu.js
+++ b/assets/js/settingsmenu.js
@@ -173,7 +173,7 @@ function loadAvailableDevices() {
         return Promise.resolve();
     }
 
-    return fetch('/api/devices', {
+    return fetch(window.nextTracePaths.joinBasePath(window.location.pathname, 'api/devices'), {
         headers: { accept: 'application/json' }
     })
         .then(function (response) {

--- a/assets/js/settingsmenu.js
+++ b/assets/js/settingsmenu.js
@@ -1,3 +1,4 @@
+var pathsApi = window.nextTracePaths;
 var settingBtn = document.getElementById('settingBtn');
 var settingMenu = document.getElementById('settingMenu');
 var settingCloseBtn = document.getElementById('settingCloseBtn');
@@ -169,11 +170,11 @@ function loadStoredSettings() {
 }
 
 function loadAvailableDevices() {
-    if (!deviceOptions || typeof fetch !== 'function') {
+    if (!deviceOptions || !pathsApi || typeof fetch !== 'function') {
         return Promise.resolve();
     }
 
-    return fetch(window.nextTracePaths.joinBasePath(window.location.pathname, 'api/devices'), {
+    return fetch(pathsApi.joinBasePath(window.location.pathname, 'api/devices'), {
         headers: { accept: 'application/json' }
     })
         .then(function (response) {

--- a/assets/js/ui-state.js
+++ b/assets/js/ui-state.js
@@ -58,12 +58,34 @@
         return url.toString();
     }
 
-    function getResolveModeLabel(localResolve) {
-        return localResolve ? 'Local Resolve' : 'Server Resolve';
+    // Translation keys are returned instead of literals so this module stays free of
+    // user-facing copy. Callers pass a translate function; without one the key comes back.
+    function createKeyTranslator(translate) {
+        if (typeof translate === 'function') {
+            return translate;
+        }
+        return function (key) {
+            return key;
+        };
     }
 
-    function buildSettingsSummary(settings) {
+    function getResolveModeKey(localResolve) {
+        return localResolve ? 'summary.resolve.local' : 'summary.resolve.server';
+    }
+
+    function getConnectionStatusKey(connectionStatus) {
+        if (connectionStatus === 'connected') {
+            return 'connection.connected';
+        }
+        if (connectionStatus === 'disconnected') {
+            return 'connection.disconnected';
+        }
+        return 'connection.connecting';
+    }
+
+    function buildSettingsSummary(settings, translate) {
         settings = settings || {};
+        var translateKey = createKeyTranslator(translate);
         var summary = [];
         var language = normalizeQuery(settings.language).toUpperCase() || 'CN';
         var intervalSeconds = Number(settings.intervalSeconds);
@@ -71,7 +93,7 @@
         var dataProvider = normalizeQuery(settings.dataProvider);
 
         summary.push(language);
-        summary.push(getResolveModeLabel(Boolean(settings.localResolve)));
+        summary.push(translateKey(getResolveModeKey(Boolean(settings.localResolve))));
 
         if (Number.isFinite(intervalSeconds) && intervalSeconds > 0) {
             summary.push(String(Math.round(intervalSeconds * 1000)) + ' ms');
@@ -86,12 +108,12 @@
         return summary;
     }
 
-    function formatTargetSummary(query, resolvedTarget) {
+    function formatTargetSummary(query, resolvedTarget, translate) {
         var normalizedQuery = normalizeQuery(query);
         var normalizedResolvedTarget = normalizeQuery(resolvedTarget);
 
         if (normalizedQuery === '' && normalizedResolvedTarget === '') {
-            return 'Not set';
+            return createKeyTranslator(translate)('target.notSet');
         }
         if (
             normalizedQuery !== '' &&
@@ -117,39 +139,39 @@
     function deriveTaskMeta(taskStatus, connectionStatus, rowCount) {
         if (connectionStatus === 'disconnected') {
             return {
-                label: 'Disconnected',
+                labelKey: 'state.disconnected.label',
                 tone: 'error',
-                detail: rowCount > 0
-                    ? 'Connection lost. Current results stay on screen.'
-                    : 'Connection lost. Reconnect before starting a new trace.'
+                detailKey: rowCount > 0
+                    ? 'state.disconnected.detail'
+                    : 'state.disconnected.detailEmpty'
             };
         }
 
         switch (taskStatus) {
         case 'resolving':
-            return { label: 'Resolving', tone: 'info', detail: 'Resolving the target before starting the trace.' };
+            return { labelKey: 'state.resolving.label', tone: 'info', detailKey: 'state.resolving.detail' };
         case 'waiting':
-            return { label: 'Waiting', tone: 'warning', detail: 'Trace started. Waiting for the first hop.' };
+            return { labelKey: 'state.waiting.label', tone: 'warning', detailKey: 'state.waiting.detail' };
         case 'running':
-            return { label: 'Running', tone: 'success', detail: 'Streaming hop data in real time.' };
+            return { labelKey: 'state.running.label', tone: 'success', detailKey: 'state.running.detail' };
         case 'complete':
             return {
-                label: 'Complete',
+                labelKey: 'state.complete.label',
                 tone: rowCount > 0 ? 'success' : 'info',
-                detail: rowCount > 0
-                    ? 'Trace finished. Results are retained until you reset.'
-                    : 'Trace finished without any hop data.'
+                detailKey: rowCount > 0
+                    ? 'state.complete.detail'
+                    : 'state.complete.detailEmpty'
             };
         case 'error':
             return {
-                label: 'Error',
+                labelKey: 'state.error.label',
                 tone: 'error',
-                detail: rowCount > 0
-                    ? 'The trace ended with an error. Current results are retained.'
-                    : 'The trace could not be started. Adjust the target or settings.'
+                detailKey: rowCount > 0
+                    ? 'state.error.detail'
+                    : 'state.error.detailEmpty'
             };
         default:
-            return { label: 'Idle', tone: 'neutral', detail: 'Ready for a new trace.' };
+            return { labelKey: 'state.idle.label', tone: 'neutral', detailKey: 'state.idle.detail' };
         }
     }
 
@@ -158,8 +180,8 @@
             return {
                 visible: false,
                 tone: 'neutral',
-                title: '',
-                description: ''
+                titleKey: '',
+                descriptionKey: ''
             };
         }
 
@@ -167,8 +189,8 @@
             return {
                 visible: true,
                 tone: 'error',
-                title: 'Disconnected',
-                description: 'The trace service is unreachable. Reconnect and start again when the session returns.'
+                titleKey: 'empty.disconnected.title',
+                descriptionKey: 'empty.disconnected.description'
             };
         }
 
@@ -177,37 +199,37 @@
             return {
                 visible: true,
                 tone: 'info',
-                title: 'Resolving target',
-                description: 'Checking the target and resolving DNS before the trace starts.'
+                titleKey: 'empty.resolving.title',
+                descriptionKey: 'empty.resolving.description'
             };
         case 'waiting':
         case 'running':
             return {
                 visible: true,
                 tone: 'warning',
-                title: 'Waiting for first hop',
-                description: 'The trace is running. Results will appear here as soon as the first hop arrives.'
+                titleKey: 'empty.waiting.title',
+                descriptionKey: 'empty.waiting.description'
             };
         case 'error':
             return {
                 visible: true,
                 tone: 'error',
-                title: 'Trace failed',
-                description: 'Adjust the target or settings, then try again.'
+                titleKey: 'empty.error.title',
+                descriptionKey: 'empty.error.description'
             };
         case 'complete':
             return {
                 visible: true,
                 tone: 'info',
-                title: 'Trace finished',
-                description: 'The task completed, but no hop data was captured.'
+                titleKey: 'empty.complete.title',
+                descriptionKey: 'empty.complete.description'
             };
         default:
             return {
                 visible: true,
                 tone: 'neutral',
-                title: 'Ready for a new trace',
-                description: 'Enter an IP, domain, or URL to start streaming hop data.'
+                titleKey: 'empty.idle.title',
+                descriptionKey: 'empty.idle.description'
             };
         }
     }
@@ -246,7 +268,8 @@
         deriveEmptyState: deriveEmptyState,
         deriveTaskMeta: deriveTaskMeta,
         formatTargetSummary: formatTargetSummary,
-        getResolveModeLabel: getResolveModeLabel,
+        getConnectionStatusKey: getConnectionStatusKey,
+        getResolveModeKey: getResolveModeKey,
         loadRecentQueries: loadRecentQueries,
         normalizeQuery: normalizeQuery,
         upsertRecentQuery: upsertRecentQuery

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,23 +1,36 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <title>NextTrace Web</title>
+    <title data-i18n="app.title">NextTrace Web</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="data:,">
-    <link rel="stylesheet" href="/assets/css/m.css" type="text/css">
-    <script src="/assets/js/socket.io.js" defer></script>
-    <script src="/assets/js/mtr-agg.js" defer></script>
-    <script src="/assets/js/ui-state.js" defer></script>
-    <script src="/assets/js/main.js" defer></script>
-    <script src="/assets/js/settingsmenu.js" defer></script>
+    <link rel="stylesheet" href="assets/css/m.css" type="text/css">
+    <script src="assets/js/socket.io.js" defer></script>
+    <script src="assets/js/paths.js" defer></script>
+    <script src="assets/js/i18n.js" defer></script>
+    <script src="assets/js/mtr-agg.js" defer></script>
+    <script src="assets/js/ui-state.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+    <script src="assets/js/settingsmenu.js" defer></script>
 </head>
 <body>
 <div class="page-shell">
     <header class="app-header">
         <div class="brand-copy">
-            <p class="eyebrow">ping.pe inspired traceroute surface</p>
+            <p class="eyebrow" data-i18n="header.eyebrow">ping.pe inspired traceroute surface</p>
             <h1>NextTrace Web</h1>
-            <p class="tagline">Stream hop-by-hop route data with a denser layout, clearer state feedback, and faster repeat workflows.</p>
+            <p class="tagline" data-i18n="header.tagline">Stream hop-by-hop route data with a denser layout, clearer state feedback, and faster repeat workflows.</p>
+        </div>
+
+        <div class="header-tools">
+            <label class="field field-language" for="uiLanguage">
+                <span class="field-label" data-i18n="header.language">Interface</span>
+                <select id="uiLanguage" name="uiLanguage" class="select-input">
+                    <option value="auto" data-i18n="language.auto">Auto</option>
+                    <option value="en">English</option>
+                    <option value="zh">中文</option>
+                </select>
+            </label>
         </div>
     </header>
 
@@ -25,12 +38,12 @@
         <form id="traceForm" class="trace-form" novalidate>
             <div class="control-row">
                 <label class="field field-target" for="params">
-                    <span class="field-label">Target</span>
-                    <input type="text" id="params" class="text-input" placeholder="IP / domain / URL" autocomplete="off">
+                    <span class="field-label" data-i18n="form.target.label">Target</span>
+                    <input type="text" id="params" class="text-input" placeholder="IP / domain / URL" data-i18n-placeholder="form.target.placeholder" autocomplete="off">
                 </label>
 
                 <label class="field field-compact" for="ipVersion">
-                    <span class="field-label">IP Version</span>
+                    <span class="field-label" data-i18n="form.ipVersion.label">IP Version</span>
                     <select id="ipVersion" name="ipVersion" class="select-input">
                         <option value="all">ALL</option>
                         <option value="ipv4">IPv4</option>
@@ -39,7 +52,7 @@
                 </label>
 
                 <label class="field field-compact" for="protocol">
-                    <span class="field-label">Protocol</span>
+                    <span class="field-label" data-i18n="form.protocol.label">Protocol</span>
                     <select id="protocol" name="protocol" class="select-input">
                         <option value="icmp">ICMP</option>
                         <option value="tcp">TCP</option>
@@ -47,39 +60,39 @@
                     </select>
                 </label>
 
-                <button type="button" id="startBtn" class="btn btn-primary">Start</button>
-                <button type="button" id="stopBtn" class="btn btn-secondary">Stop</button>
-                <button type="button" id="resetBtn" class="btn btn-ghost">Reset</button>
-                <button type="button" id="settingBtn" class="btn btn-ghost" aria-controls="settingMenu" aria-expanded="false">Settings</button>
+                <button type="button" id="startBtn" class="btn btn-primary" data-i18n="action.start">Start</button>
+                <button type="button" id="stopBtn" class="btn btn-secondary" data-i18n="action.stop">Stop</button>
+                <button type="button" id="resetBtn" class="btn btn-ghost" data-i18n="action.reset">Reset</button>
+                <button type="button" id="settingBtn" class="btn btn-ghost" aria-controls="settingMenu" aria-expanded="false" data-i18n="action.settings">Settings</button>
             </div>
 
             <div class="status-strip">
                 <div class="status-primary">
-                    <span id="taskStatusBadge" class="status-badge" data-tone="neutral">Idle</span>
-                    <p id="taskStatusDetail" class="status-detail">Ready for a new trace.</p>
+                    <span id="taskStatusBadge" class="status-badge" data-tone="neutral" data-i18n="state.idle.label">Idle</span>
+                    <p id="taskStatusDetail" class="status-detail" data-i18n="state.idle.detail">Ready for a new trace.</p>
                 </div>
 
                 <div class="status-facts">
                     <div class="status-fact">
-                        <span class="fact-label">Target</span>
-                        <span id="targetSummary" class="fact-value">Not set</span>
+                        <span class="fact-label" data-i18n="status.fact.target">Target</span>
+                        <span id="targetSummary" class="fact-value" data-i18n="target.notSet">Not set</span>
                     </div>
                     <div class="status-fact">
-                        <span class="fact-label">Connection</span>
-                        <span id="connectionSummary" class="fact-value">Connecting</span>
+                        <span class="fact-label" data-i18n="status.fact.connection">Connection</span>
+                        <span id="connectionSummary" class="fact-value" data-i18n="connection.connecting">Connecting</span>
                     </div>
                     <div class="status-fact">
-                        <span class="fact-label">Resolve</span>
-                        <span id="resolveModeSummary" class="fact-value">Local Resolve</span>
+                        <span class="fact-label" data-i18n="status.fact.resolve">Resolve</span>
+                        <span id="resolveModeSummary" class="fact-value" data-i18n="summary.resolve.local">Local Resolve</span>
                     </div>
                     <div class="status-fact">
-                        <span class="fact-label">Settings</span>
+                        <span class="fact-label" data-i18n="status.fact.settings">Settings</span>
                         <span id="settingsSummaryInline" class="fact-value">CN · Local Resolve</span>
                     </div>
                 </div>
 
                 <div class="status-tools">
-                    <button type="button" id="shareBtn" class="btn btn-inline">Copy Share Link</button>
+                    <button type="button" id="shareBtn" class="btn btn-inline" data-i18n="action.share">Copy Share Link</button>
                 </div>
             </div>
         </form>
@@ -90,18 +103,18 @@
             <div id="noticeBanner" class="notice-banner" data-tone="info" hidden></div>
 
             <div id="resultEmptyState" class="result-state" data-tone="neutral">
-                <p class="eyebrow">trace state</p>
-                <h2 id="resultStateTitle">Ready for a new trace</h2>
-                <p id="resultStateText">Enter an IP, domain, or URL to start streaming hop data.</p>
+                <p class="eyebrow" data-i18n="results.eyebrow">trace state</p>
+                <h2 id="resultStateTitle" data-i18n="empty.idle.title">Ready for a new trace</h2>
+                <p id="resultStateText" data-i18n="empty.idle.description">Enter an IP, domain, or URL to start streaming hop data.</p>
             </div>
 
             <div class="table-panel">
                 <div class="table-panel-header">
                     <div>
-                        <p class="eyebrow">streaming hop view</p>
-                        <h2>Trace Output</h2>
+                        <p class="eyebrow" data-i18n="table.eyebrow">streaming hop view</p>
+                        <h2 data-i18n="table.title">Trace Output</h2>
                     </div>
-                    <p class="table-hint">Sticky header, horizontal scroll on narrow screens, raw TTL aggregation unchanged.</p>
+                    <p class="table-hint" data-i18n="table.hint">Sticky header, horizontal scroll on narrow screens, raw TTL aggregation unchanged.</p>
                 </div>
 
                 <div class="table-shell">
@@ -132,21 +145,21 @@
             <section class="helper-card">
                 <div class="helper-card-header">
                     <div>
-                        <p class="eyebrow">history</p>
-                        <h2>Recent Queries</h2>
+                        <p class="eyebrow" data-i18n="panel.history.eyebrow">history</p>
+                        <h2 data-i18n="panel.history.title">Recent Queries</h2>
                     </div>
-                    <span class="helper-card-meta">stored locally</span>
+                    <span class="helper-card-meta" data-i18n="panel.history.meta">stored locally</span>
                 </div>
                 <div id="recentQueries" class="chip-list chip-list-empty">
-                    <span class="helper-empty">Your recent traces will appear here.</span>
+                    <span class="helper-empty" data-i18n="panel.history.empty">Your recent traces will appear here.</span>
                 </div>
             </section>
 
             <section class="helper-card">
                 <div class="helper-card-header">
                     <div>
-                        <p class="eyebrow">quick start</p>
-                        <h2>Example Targets</h2>
+                        <p class="eyebrow" data-i18n="panel.examples.eyebrow">quick start</p>
+                        <h2 data-i18n="panel.examples.title">Example Targets</h2>
                     </div>
                 </div>
                 <div class="chip-list">
@@ -162,8 +175,8 @@
             <section class="helper-card">
                 <div class="helper-card-header">
                     <div>
-                        <p class="eyebrow">effective configuration</p>
-                        <h2>Current Settings</h2>
+                        <p class="eyebrow" data-i18n="panel.settings.eyebrow">effective configuration</p>
+                        <h2 data-i18n="panel.settings.title">Current Settings</h2>
                     </div>
                 </div>
                 <div id="settingsSummaryPanel" class="chip-list"></div>
@@ -184,31 +197,31 @@
 >
     <div class="drawer-header">
         <div>
-            <p class="eyebrow">runtime settings</p>
-            <h2 id="settingsDrawerTitle">Trace Settings</h2>
+            <p class="eyebrow" data-i18n="settings.eyebrow">runtime settings</p>
+            <h2 id="settingsDrawerTitle" data-i18n="settings.title">Trace Settings</h2>
         </div>
-        <button type="button" id="settingCloseBtn" class="drawer-close" aria-label="Close settings">&times;</button>
+        <button type="button" id="settingCloseBtn" class="drawer-close" aria-label="Close settings" data-i18n-aria-label="settings.close">&times;</button>
     </div>
 
     <div class="settings-grid">
         <label class="field" for="language">
-            <span class="field-label">Language</span>
+            <span class="field-label" data-i18n="settings.language.label">Geo Data Language</span>
             <select id="language" name="language" class="select-input">
-                <option value="cn">Chinese</option>
-                <option value="en">English</option>
+                <option value="cn" data-i18n="settings.language.zh">Chinese</option>
+                <option value="en" data-i18n="settings.language.en">English</option>
             </select>
         </label>
 
         <label class="field field-toggle" for="localResolveCheckbox">
-            <span class="field-label">Resolve Mode</span>
+            <span class="field-label" data-i18n="settings.resolve.label">Resolve Mode</span>
             <span class="toggle-card">
                 <input type="checkbox" id="localResolveCheckbox" checked>
-                <span>Prefer local DoH resolve before starting the trace</span>
+                <span data-i18n="settings.resolve.hint">Prefer local DoH resolve before starting the trace</span>
             </span>
         </label>
 
         <label class="field field-span-2" for="intervalTimeSlider">
-            <span class="field-label">Probe Interval Seconds</span>
+            <span class="field-label" data-i18n="settings.interval.label">Probe Interval Seconds</span>
             <div id="intervalTimeSlider" class="range-pair">
                 <input type="range" id="intervalTimeRange" min="0.005" max="1" step="0.001" value="0.040">
                 <input type="number" id="intervalTimeInput" min="0.005" max="1" step="0.001" value="0.040">
@@ -216,7 +229,7 @@
         </label>
 
         <label class="field field-span-2" for="packetSizeSlider">
-            <span class="field-label">Packet Size</span>
+            <span class="field-label" data-i18n="settings.packetSize.label">Packet Size</span>
             <div id="packetSizeSlider" class="range-pair">
                 <input type="range" id="packetSizeRange" min="0" max="1500" step="1" value="52">
                 <input type="number" id="packetSizeInput" min="0" max="1500" step="1" value="52">
@@ -224,30 +237,30 @@
         </label>
 
         <label class="field" for="maxHopInput">
-            <span class="field-label">Max Hop</span>
+            <span class="field-label" data-i18n="settings.maxHop.label">Max Hop</span>
             <input type="number" id="maxHopInput" class="text-input" min="1" max="30" step="1" value="30">
         </label>
 
         <label class="field" for="minHopInput">
-            <span class="field-label">Min Hop</span>
+            <span class="field-label" data-i18n="settings.minHop.label">Min Hop</span>
             <input type="number" id="minHopInput" class="text-input" min="1" max="30" step="1" value="1">
         </label>
 
         <label class="field" for="portInput">
-            <span class="field-label">Port</span>
+            <span class="field-label" data-i18n="settings.port.label">Port</span>
             <input type="number" id="portInput" class="text-input" min="1" max="65535" step="1" value="80">
         </label>
 
         <label class="field" for="devInput">
-            <span class="field-label">Device</span>
-            <input type="text" id="devInput" class="text-input" list="deviceOptions" placeholder="Device">
+            <span class="field-label" data-i18n="settings.device.label">Device</span>
+            <input type="text" id="devInput" class="text-input" list="deviceOptions" placeholder="Device" data-i18n-placeholder="settings.device.placeholder">
             <datalist id="deviceOptions"></datalist>
-            <span id="dev-error-message" class="validation-message">Invalid device name.</span>
+            <span id="dev-error-message" class="validation-message" data-i18n="settings.device.error">Invalid device name.</span>
         </label>
 
         <label class="field field-span-2" for="dataProvider">
-            <span class="field-label">Geo Data Provider</span>
-            <input type="text" list="dataProviders" id="dataProvider" class="text-input" placeholder="dataProvider">
+            <span class="field-label" data-i18n="settings.dataProvider.label">Geo Data Provider</span>
+            <input type="text" list="dataProviders" id="dataProvider" class="text-input" placeholder="dataProvider" data-i18n-placeholder="settings.dataProvider.placeholder">
             <datalist id="dataProviders">
                 <option value="LeoMoeAPI">
                 <option value="Ip2region">
@@ -259,12 +272,12 @@
                 <option value="Chunzhen">
                 <option value="Disable-geoip">
             </datalist>
-            <span id="dp-error-message" class="validation-message">Invalid data provider.</span>
+            <span id="dp-error-message" class="validation-message" data-i18n="settings.dataProvider.error">Invalid data provider.</span>
         </label>
     </div>
 
     <div class="drawer-actions">
-        <button type="button" id="saveBtn" class="btn btn-primary">Save Settings</button>
+        <button type="button" id="saveBtn" class="btn btn-primary" data-i18n="settings.save">Save Settings</button>
     </div>
 </aside>
 
@@ -272,10 +285,10 @@
     <div class="modal-card">
         <div class="modal-header">
             <div>
-                <p class="eyebrow">resolver result</p>
-                <h2 id="ipSelectorTitle">请选择一个IP地址</h2>
+                <p class="eyebrow" data-i18n="modal.ipSelector.eyebrow">resolver result</p>
+                <h2 id="ipSelectorTitle" data-i18n="modal.ipSelector.title">Choose a resolved IP</h2>
             </div>
-            <button type="button" class="drawer-close" id="ipSelectorClose" aria-label="Close selector">&times;</button>
+            <button type="button" class="drawer-close" id="ipSelectorClose" aria-label="Close selector" data-i18n-aria-label="modal.close">&times;</button>
         </div>
         <div id="ip-list" class="modal-list"></div>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,8 +27,8 @@
                 <span class="field-label" data-i18n="header.language">Interface</span>
                 <select id="uiLanguage" name="uiLanguage" class="select-input">
                     <option value="auto" data-i18n="language.auto">Auto</option>
-                    <option value="en">English</option>
-                    <option value="zh">中文</option>
+                    <option value="en" lang="en">English</option>
+                    <option value="zh" lang="zh-CN">中文</option>
                 </select>
             </label>
         </div>

--- a/tests/asset-paths.test.cjs
+++ b/tests/asset-paths.test.cjs
@@ -1,0 +1,183 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { joinBasePath, resolveBasePath } = require('../assets/js/paths.js');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('resolveBasePath keeps the directory portion of the current path', () => {
+  assert.equal(resolveBasePath('/'), '/');
+  assert.equal(resolveBasePath('/trace/'), '/trace/');
+  assert.equal(resolveBasePath('/a/b/'), '/a/b/');
+  assert.equal(resolveBasePath('/trace/index.html'), '/trace/');
+});
+
+test('resolveBasePath drops the trailing segment of a file-like path', () => {
+  assert.equal(resolveBasePath('/trace'), '/');
+  assert.equal(resolveBasePath('/a/b'), '/a/');
+});
+
+test('resolveBasePath ignores the query string and fragment', () => {
+  assert.equal(resolveBasePath('/trace/?trace=1.1.1.1'), '/trace/');
+  assert.equal(resolveBasePath('/trace/#hash'), '/trace/');
+});
+
+test('resolveBasePath normalizes missing or relative input', () => {
+  assert.equal(resolveBasePath(''), '/');
+  assert.equal(resolveBasePath(undefined), '/');
+  assert.equal(resolveBasePath(null), '/');
+  assert.equal(resolveBasePath('trace/'), '/trace/');
+});
+
+test('joinBasePath builds sub-path aware endpoints', () => {
+  assert.equal(joinBasePath('/', 'socket.io'), '/socket.io');
+  assert.equal(joinBasePath('/', 'api/devices'), '/api/devices');
+  assert.equal(joinBasePath('/trace/', 'socket.io'), '/trace/socket.io');
+  assert.equal(joinBasePath('/trace/', 'api/devices'), '/trace/api/devices');
+  assert.equal(joinBasePath('/trace/', '/api/devices'), '/trace/api/devices');
+  assert.equal(joinBasePath('/trace/', ''), '/trace/');
+  assert.equal(joinBasePath('/trace/', undefined), '/trace/');
+});
+
+test('the template references every asset with a relative path', () => {
+  const html = readRepoFile('templates/index.html');
+  const referencePattern = /(?:src|href)="([^"]+)"/g;
+  const rootRelative = [];
+  let match = referencePattern.exec(html);
+
+  while (match !== null) {
+    const reference = match[1];
+    if (reference.startsWith('/')) {
+      rootRelative.push(reference);
+    }
+    match = referencePattern.exec(html);
+  }
+
+  assert.deepEqual(rootRelative, []);
+  assert.ok(html.includes('href="assets/css/m.css"'));
+  assert.ok(html.includes('src="assets/js/main.js"'));
+});
+
+test('the stylesheet resolves its font relative to itself', () => {
+  const css = readRepoFile('assets/css/m.css');
+
+  assert.ok(css.includes('url(../font/roboto-mono-latin.woff2)'));
+  assert.equal(/url\(\/\S/.test(css), false, 'no stylesheet url() may start at the site root');
+});
+
+// The regex scans above only prove the absence of a leading slash. These two resolve the
+// references the way a browser does, so they also prove the references land somewhere real.
+test('template asset references resolve under both root and sub-path deployments', () => {
+  const html = readRepoFile('templates/index.html');
+  const pattern = /(?:src|href)="([^"]+)"/g;
+  const references = [];
+  let match = pattern.exec(html);
+
+  while (match !== null) {
+    if (!match[1].startsWith('data:')) {
+      references.push(match[1]);
+    }
+    match = pattern.exec(html);
+  }
+
+  assert.ok(references.length >= 7, `expected the asset references, found ${references.length}`);
+
+  references.forEach((reference) => {
+    assert.equal(
+      new URL(reference, 'https://example.com/tools/nexttrace/').href,
+      `https://example.com/tools/nexttrace/${reference}`
+    );
+    assert.equal(
+      new URL(reference, 'https://example.com/').href,
+      `https://example.com/${reference}`
+    );
+  });
+});
+
+// A relative reference passes the scans above even when it points at nothing, and a
+// missing script leaves its global undefined and breaks the page on load.
+test('every template asset reference points at a file that exists', () => {
+  const html = readRepoFile('templates/index.html');
+  const pattern = /(?:src|href)="([^"]+)"/g;
+  const missing = [];
+  let referenceCount = 0;
+  let match = pattern.exec(html);
+
+  while (match !== null) {
+    const reference = match[1];
+    if (!reference.startsWith('data:')) {
+      referenceCount += 1;
+      if (!fs.existsSync(path.join(repoRoot, reference))) {
+        missing.push(reference);
+      }
+    }
+    match = pattern.exec(html);
+  }
+
+  assert.ok(referenceCount >= 7, `expected the asset references, found ${referenceCount}`);
+  assert.deepEqual(missing, []);
+});
+
+test('every script the page needs at parse time is loaded before its consumers', () => {
+  const html = readRepoFile('templates/index.html');
+  const scriptPattern = /<script src="([^"]+)"/g;
+  const order = [];
+  let match = scriptPattern.exec(html);
+
+  while (match !== null) {
+    order.push(match[1]);
+    match = scriptPattern.exec(html);
+  }
+
+  // main.js reads window.nextTracePaths/nextTraceI18n/nextTraceMTRAgg/nextTraceUIState at
+  // its top level, and settingsmenu.js reads window.nextTracePaths, so both must come last.
+  const providers = [
+    'assets/js/socket.io.js',
+    'assets/js/paths.js',
+    'assets/js/i18n.js',
+    'assets/js/mtr-agg.js',
+    'assets/js/ui-state.js'
+  ];
+
+  providers.forEach((provider) => {
+    const providerIndex = order.indexOf(provider);
+    assert.notEqual(providerIndex, -1, `${provider} should be loaded by the template`);
+    assert.ok(
+      providerIndex < order.indexOf('assets/js/main.js'),
+      `${provider} must load before main.js`
+    );
+    assert.ok(
+      providerIndex < order.indexOf('assets/js/settingsmenu.js'),
+      `${provider} must load before settingsmenu.js`
+    );
+  });
+});
+
+test('the stylesheet font url resolves next to the stylesheet, not at the site root', () => {
+  const css = readRepoFile('assets/css/m.css');
+  const fontMatch = css.match(/url\(([^)]+)\)/);
+
+  assert.ok(fontMatch, 'the stylesheet should declare a font url');
+  assert.equal(
+    new URL(fontMatch[1], 'https://example.com/tools/nexttrace/assets/css/m.css').href,
+    'https://example.com/tools/nexttrace/assets/font/roboto-mono-latin.woff2'
+  );
+});
+
+test('browser scripts do not hardcode root-anchored endpoints', () => {
+  ['assets/js/main.js', 'assets/js/settingsmenu.js', 'assets/js/ui-state.js', 'assets/js/i18n.js']
+    .forEach((relativePath) => {
+      const source = readRepoFile(relativePath);
+      assert.equal(
+        /['"]\/(?:assets|api|socket\.io)\//.test(source),
+        false,
+        `${relativePath} must build request paths from the current base path`
+      );
+    });
+});

--- a/tests/asset-paths.test.cjs
+++ b/tests/asset-paths.test.cjs
@@ -45,6 +45,20 @@ test('joinBasePath builds sub-path aware endpoints', () => {
   assert.equal(joinBasePath('/trace/', undefined), '/trace/');
 });
 
+test('documented sub-path redirects preserve query strings', () => {
+  ['README.md', 'README.zh-CN.md'].forEach((relativePath) => {
+    const readme = readRepoFile(relativePath);
+    const locationBlock = readme.match(/location = \/tools\/nexttrace\s*\{([\s\S]*?)\}/);
+
+    assert.ok(locationBlock, `${relativePath} should document the no-slash redirect`);
+    assert.match(
+      locationBlock[1],
+      /^\s*return 301 \/tools\/nexttrace\/\$is_args\$args;\s*$/m,
+      `${relativePath} should preserve the original query string`
+    );
+  });
+});
+
 test('the template references every asset with a relative path', () => {
   const html = readRepoFile('templates/index.html');
   const referencePattern = /(?:src|href)="([^"]+)"/g;

--- a/tests/browser-controls.check.cjs
+++ b/tests/browser-controls.check.cjs
@@ -17,6 +17,7 @@ const quietConsole = {
 async function main() {
   const checks = [
     checkSettingsOverlayMarkup,
+    checkHarnessMirrorsTemplate,
     checkSettingsDrawerControls,
     checkSettingsInputSync,
     checkSettingsPersistenceAndSummary,
@@ -24,7 +25,11 @@ async function main() {
     checkPrimaryControls,
     checkShareControl,
     checkIpSelectorControl,
-    checkTraceQueryAutostart
+    checkTraceQueryAutostart,
+    checkAutomaticLanguageDetection,
+    checkLanguageSwitcher,
+    checkNoticeFollowsLanguageSwitch,
+    checkSubPathDeployment
   ];
 
   for (const check of checks) {
@@ -43,6 +48,42 @@ async function checkSettingsOverlayMarkup() {
   assert.equal(controlPanel[1].includes('id="settingMenu"'), false);
   assert.equal(controlPanel[1].includes('id="settingsBackdrop"'), false);
   assert.ok(html.includes('<aside\n    id="settingMenu"'));
+}
+
+// The harness hand-builds its DOM instead of parsing templates/index.html, so every check
+// below would keep passing if an element were dropped from the real page. This ties the two
+// together: anything the harness drives must actually exist in the template.
+async function checkHarnessMirrorsTemplate() {
+  const html = fs.readFileSync(path.join(repoRoot, 'templates/index.html'), 'utf8');
+  const templateIds = new Set();
+  const idPattern = /id="([^"]+)"/g;
+  let match = idPattern.exec(html);
+
+  while (match !== null) {
+    templateIds.add(match[1]);
+    match = idPattern.exec(html);
+  }
+
+  const harness = createBrowserHarness({ console: quietConsole });
+  // Containers the harness invents only to parent its fixtures; the real template groups
+  // the same elements without needing an id on the wrapper.
+  const harnessOnlyContainers = new Set(['appHeader', 'exampleTargets']);
+  const missingFromTemplate = Array.from(harness.document.elementsById.keys())
+    .filter((id) => !harnessOnlyContainers.has(id) && !templateIds.has(id))
+    .sort();
+
+  assert.deepEqual(
+    missingFromTemplate,
+    [],
+    'the harness drives elements the real template does not ship'
+  );
+
+  // The language switcher is the newest of these, and its options carry behaviour the id
+  // check alone cannot see.
+  assert.match(html, /<select id="uiLanguage"/);
+  assert.match(html, /<option value="auto"[^>]*data-i18n="language\.auto"/);
+  assert.match(html, /<option value="en">English<\/option>/);
+  assert.match(html, /<option value="zh">中文<\/option>/);
 }
 
 async function checkSettingsDrawerControls() {
@@ -270,6 +311,178 @@ async function checkTraceQueryAutostart() {
   assert.equal(elements.ipVersion.value, 'ipv4');
   assert.equal(elements.protocol.value, 'tcp');
   assert.equal(socket.emitted.some((packet) => packet.name === 'start_nexttrace'), true);
+}
+
+async function checkAutomaticLanguageDetection() {
+  const englishHarness = createBrowserHarness({
+    console: quietConsole,
+    languages: ['en-GB', 'fr-FR']
+  });
+
+  assert.equal(englishHarness.elements.uiLanguage.value, 'auto');
+  assert.equal(englishHarness.elements.startBtn.textContent, 'Start');
+  assert.equal(englishHarness.localStorage.getItem('uiLanguage'), null);
+
+  const chineseHarness = createBrowserHarness({
+    console: quietConsole,
+    languages: ['zh-CN', 'en-US']
+  });
+
+  assert.equal(chineseHarness.elements.uiLanguage.value, 'auto');
+  assert.equal(chineseHarness.elements.startBtn.textContent, '开始');
+  assert.equal(chineseHarness.document.documentElement.getAttribute('lang'), 'zh-CN');
+  assert.ok(chineseHarness.elements.tbody.innerHTML.includes('<th>跳数</th>'));
+
+  const overriddenHarness = createBrowserHarness({
+    console: quietConsole,
+    languages: ['zh-CN'],
+    storage: { uiLanguage: 'en' }
+  });
+
+  assert.equal(overriddenHarness.elements.uiLanguage.value, 'en');
+  assert.equal(overriddenHarness.elements.startBtn.textContent, 'Start');
+}
+
+async function checkLanguageSwitcher() {
+  const harness = createBrowserHarness({ console: quietConsole });
+  const { document, localStorage, elements } = harness;
+
+  assert.equal(elements.uiLanguage.value, 'auto');
+  assert.equal(elements.startBtn.textContent, 'Start');
+  assert.equal(elements.taskStatusBadge.textContent, 'Idle');
+  assert.equal(elements.resultStateTitle.textContent, 'Ready for a new trace');
+  assert.equal(document.documentElement.getAttribute('lang'), 'en');
+
+  elements.uiLanguage.value = 'zh';
+  harness.dispatchChange(elements.uiLanguage);
+  await harness.flushPromises();
+
+  assert.equal(localStorage.getItem('uiLanguage'), 'zh');
+  assert.equal(document.documentElement.getAttribute('lang'), 'zh-CN');
+  assert.equal(elements.startBtn.textContent, '开始');
+  assert.equal(elements.stopBtn.textContent, '停止');
+  assert.equal(elements.saveBtn.textContent, '保存设置');
+  assert.equal(elements.shareBtn.textContent, '复制分享链接');
+  assert.equal(elements.params.getAttribute('placeholder'), 'IP / 域名 / URL');
+  assert.equal(elements.taskStatusBadge.textContent, '空闲');
+  assert.equal(elements.resultStateTitle.textContent, '已就绪，可以开始新的追踪');
+  assert.equal(elements.targetSummary.textContent, '未设置');
+  assert.equal(elements.resolveModeSummary.textContent, '本地解析');
+  assert.match(elements.settingsSummaryInline.textContent, /本地解析/);
+  assert.ok(elements.tbody.innerHTML.includes('<th>跳数</th>'));
+  assert.equal(elements.tbody.innerHTML.includes('<th>HOP</th>'), false);
+
+  harness.socket.trigger('nexttrace_error', {});
+  assert.equal(elements.noticeBanner.textContent, '任务执行失败。');
+  assert.equal(elements.taskStatusBadge.textContent, '出错');
+
+  harness.socket.trigger('disconnect');
+  assert.equal(elements.taskStatusBadge.textContent, '已断开');
+  assert.match(elements.noticeBanner.textContent, /连接已断开/);
+  assert.equal(elements.connectionSummary.textContent, '已断开');
+
+  elements.uiLanguage.value = 'auto';
+  harness.dispatchChange(elements.uiLanguage);
+  await harness.flushPromises();
+
+  assert.equal(localStorage.getItem('uiLanguage'), 'auto');
+  assert.equal(elements.startBtn.textContent, 'Start');
+  assert.equal(elements.taskStatusBadge.textContent, 'Disconnected');
+  assert.ok(elements.tbody.innerHTML.includes('<th>HOP</th>'));
+}
+
+async function checkNoticeFollowsLanguageSwitch() {
+  const harness = createBrowserHarness({ console: quietConsole });
+  const { elements } = harness;
+
+  // nexttrace's own diagnostic output has no translation key and must survive verbatim.
+  harness.socket.trigger('nexttrace_error', {
+    code: 'nexttrace_exit_nonzero',
+    message: 'nexttrace: operation not permitted'
+  });
+  assert.equal(elements.noticeBanner.textContent, 'nexttrace: operation not permitted');
+  assert.equal(elements.taskStatusBadge.textContent, 'Error');
+
+  elements.uiLanguage.value = 'zh';
+  harness.dispatchChange(elements.uiLanguage);
+  await harness.flushPromises();
+
+  assert.equal(elements.noticeBanner.textContent, 'nexttrace: operation not permitted');
+  assert.equal(elements.taskStatusBadge.textContent, '出错');
+
+  // A known backend code is replaced with localized copy, not the Chinese server string.
+  harness.socket.trigger('nexttrace_error', {
+    code: 'trace_rate_limited',
+    message: '操作过于频繁，请稍后再试',
+    retry_after_seconds: 1
+  });
+  assert.equal(elements.noticeBanner.textContent, '操作过于频繁，请稍后再试。');
+
+  elements.uiLanguage.value = 'en';
+  harness.dispatchChange(elements.uiLanguage);
+  await harness.flushPromises();
+
+  assert.match(elements.noticeBanner.textContent, /Too many requests/);
+
+  elements.uiLanguage.value = 'zh';
+  harness.dispatchChange(elements.uiLanguage);
+  await harness.flushPromises();
+
+  // A keyed notice re-renders in whichever language is active.
+  harness.socket.trigger('nexttrace_error', {});
+  assert.equal(elements.noticeBanner.textContent, '任务执行失败。');
+
+  elements.uiLanguage.value = 'en';
+  harness.dispatchChange(elements.uiLanguage);
+  await harness.flushPromises();
+
+  assert.equal(elements.noticeBanner.textContent, 'The trace task failed.');
+
+  // The regression this guards: a notice raised while English must turn Chinese on switch,
+  // so the banner state cannot hold already-translated text.
+  harness.socket.trigger('disconnect');
+  assert.match(elements.noticeBanner.textContent, /Connection to the trace service was lost/);
+
+  elements.uiLanguage.value = 'zh';
+  harness.dispatchChange(elements.uiLanguage);
+  await harness.flushPromises();
+
+  assert.match(elements.noticeBanner.textContent, /与追踪服务的连接已断开/);
+  assert.equal(elements.taskStatusBadge.textContent, '已断开');
+}
+
+async function checkSubPathDeployment() {
+  const requestedUrls = [];
+  const harness = createBrowserHarness({
+    console: quietConsole,
+    url: 'https://trace.example/tools/nexttrace/',
+    fetch(url) {
+      requestedUrls.push(url);
+      return Promise.resolve({
+        ok: true,
+        json() {
+          return Promise.resolve({ devices: ['en0'], count: 1 });
+        }
+      });
+    }
+  });
+  await harness.flushPromises();
+
+  assert.deepEqual(requestedUrls, ['/tools/nexttrace/api/devices']);
+  assert.equal(harness.socketConnections.length, 1);
+  assert.equal(harness.socketConnections[0].options.path, '/tools/nexttrace/socket.io');
+
+  const rootHarness = createBrowserHarness({ console: quietConsole });
+  assert.equal(rootHarness.socketConnections[0].options.path, '/socket.io');
+
+  harness.elements.params.value = 'example.com';
+  harness.dispatchInput(harness.elements.params);
+  harness.elements.shareBtn.click();
+  await harness.flushPromises();
+
+  assert.deepEqual(harness.clipboardWrites, [
+    'https://trace.example/tools/nexttrace/?trace=example.com'
+  ]);
 }
 
 main().catch((error) => {

--- a/tests/browser-controls.check.cjs
+++ b/tests/browser-controls.check.cjs
@@ -78,12 +78,50 @@ async function checkHarnessMirrorsTemplate() {
     'the harness drives elements the real template does not ship'
   );
 
+  const templateTagsById = new Map();
+  const openingTagPattern = /<[a-z][a-z0-9-]*\b[^>]*\bid="([^"]+)"[^>]*>/gi;
+  const i18nAttributes = [
+    'data-i18n',
+    'data-i18n-placeholder',
+    'data-i18n-aria-label',
+    'data-i18n-title'
+  ];
+  match = openingTagPattern.exec(html);
+  while (match !== null) {
+    templateTagsById.set(match[1], match[0]);
+    match = openingTagPattern.exec(html);
+  }
+
+  const contractIds = new Set([
+    ...templateTagsById.keys(),
+    ...harness.document.elementsById.keys()
+  ]);
+  contractIds.forEach((id) => {
+    const element = harness.document.elementsById.get(id);
+    const openingTag = templateTagsById.get(id);
+    i18nAttributes.forEach((attribute) => {
+      const harnessValue = element ? element.getAttribute(attribute) : undefined;
+      const attributeMatch = openingTag
+        ? openingTag.match(new RegExp(`\\b${attribute}="([^"]*)"`))
+        : null;
+      const templateValue = attributeMatch ? attributeMatch[1] : undefined;
+
+      if (harnessValue === undefined && templateValue === undefined) {
+        return;
+      }
+
+      assert.ok(element, `${id} should exist in the harness`);
+      assert.ok(openingTag, `${id} should exist in the template`);
+      assert.equal(harnessValue, templateValue, `${id} should use the same ${attribute} key`);
+    });
+  });
+
   // The language switcher is the newest of these, and its options carry behaviour the id
   // check alone cannot see.
   assert.match(html, /<select id="uiLanguage"/);
-  assert.match(html, /<option value="auto"[^>]*data-i18n="language\.auto"/);
-  assert.match(html, /<option value="en">English<\/option>/);
-  assert.match(html, /<option value="zh">中文<\/option>/);
+  assert.match(html, /<option\b(?=[^>]*\bvalue="auto")(?=[^>]*\bdata-i18n="language\.auto")[^>]*>\s*Auto\s*<\/option>/);
+  assert.match(html, /<option\b(?=[^>]*\bvalue="en")(?=[^>]*\blang="en")[^>]*>\s*English\s*<\/option>/);
+  assert.match(html, /<option\b(?=[^>]*\bvalue="zh")(?=[^>]*\blang="zh-CN")[^>]*>\s*中文\s*<\/option>/);
 }
 
 async function checkSettingsDrawerControls() {
@@ -423,10 +461,52 @@ async function checkNoticeFollowsLanguageSwitch() {
   await harness.flushPromises();
 
   assert.match(elements.noticeBanner.textContent, /Too many requests/);
+  assert.equal(elements.noticeBanner.textContent.includes('操作过于频繁'), false);
+
+  // Consecutive messages for the same code replace the previous raw detail.
+  [
+    {
+      code: 'invalid_payload',
+      message: 'maxHop 超出允许范围',
+      summary: /The server rejected one of the trace settings/
+    },
+    {
+      code: 'invalid_payload',
+      message: 'port 不是合法整数',
+      summary: /The server rejected one of the trace settings/
+    }
+  ].forEach((error) => {
+    harness.socket.trigger('nexttrace_error', error);
+    assert.match(elements.noticeBanner.textContent, error.summary);
+    assert.match(elements.noticeBanner.textContent, new RegExp(error.message));
+  });
+  assert.equal(elements.noticeBanner.textContent.includes('maxHop 超出允许范围'), false);
+
+  // Every code with parameter-specific diagnostics retains the raw detail alongside its
+  // localized summary.
+  [
+    {
+      code: 'invalid_target',
+      message: '目标地址格式不合法',
+      summary: /The server rejected the target address/
+    },
+    {
+      code: 'trace_not_running',
+      message: '任务已结束，无法继续输入',
+      summary: /There is no running trace to interact with/
+    }
+  ].forEach((error) => {
+    harness.socket.trigger('nexttrace_error', error);
+    assert.match(elements.noticeBanner.textContent, error.summary);
+    assert.match(elements.noticeBanner.textContent, new RegExp(error.message));
+  });
 
   elements.uiLanguage.value = 'zh';
   harness.dispatchChange(elements.uiLanguage);
   await harness.flushPromises();
+
+  assert.match(elements.noticeBanner.textContent, /当前没有正在运行的 trace 任务/);
+  assert.match(elements.noticeBanner.textContent, /任务已结束，无法继续输入/);
 
   // A keyed notice re-renders in whichever language is active.
   harness.socket.trigger('nexttrace_error', {});

--- a/tests/browser-harness.cjs
+++ b/tests/browser-harness.cjs
@@ -286,7 +286,7 @@ function matchesSelector(element, selector) {
   if (selector.startsWith('.')) {
     return element.classList.contains(selector.slice(1));
   }
-  const dataSelector = selector.match(/^\[data-([a-z-]+)\]$/);
+  const dataSelector = selector.match(/^\[data-([a-z0-9-]+)\]$/);
   if (dataSelector) {
     return Object.prototype.hasOwnProperty.call(element.dataset, toCamelCase(dataSelector[1]));
   }
@@ -371,6 +371,7 @@ function createBrowserHarness(options = {}) {
   const document = new FakeDocument(options.url || 'https://example.test/');
   const localStorage = new FakeStorage(options.storage || {});
   const socket = createSocket();
+  const socketConnections = [];
   const clipboardWrites = [];
   const consoleObject = options.console || console;
   const windowObject = {
@@ -378,6 +379,7 @@ function createBrowserHarness(options = {}) {
     localStorage,
     location: document.location,
     navigator: {
+      languages: options.languages,
       clipboard: {
         writeText(text) {
           clipboardWrites.push(text);
@@ -388,21 +390,47 @@ function createBrowserHarness(options = {}) {
   };
 
   const body = document.body;
+  const appHeader = appendElement(document, body, 'header', 'appHeader');
+  const uiLanguage = appendElement(document, appHeader, 'select', 'uiLanguage', { value: 'auto' });
+  appendElement(document, uiLanguage, 'option', '', {
+    value: 'auto',
+    textContent: 'Auto',
+    attributes: { 'data-i18n': 'language.auto' }
+  });
+  appendElement(document, uiLanguage, 'option', '', { value: 'en', textContent: 'English' });
+  appendElement(document, uiLanguage, 'option', '', { value: 'zh', textContent: '中文' });
+
   const traceForm = appendElement(document, body, 'form', 'traceForm');
-  const params = appendElement(document, traceForm, 'input', 'params', { type: 'text' });
+  const params = appendElement(document, traceForm, 'input', 'params', {
+    type: 'text',
+    attributes: { 'data-i18n-placeholder': 'form.target.placeholder' }
+  });
   const ipVersion = appendElement(document, traceForm, 'select', 'ipVersion', { value: 'all' });
   const protocol = appendElement(document, traceForm, 'select', 'protocol', { value: 'icmp' });
-  const startBtn = appendElement(document, traceForm, 'button', 'startBtn', { textContent: 'Start' });
-  const stopBtn = appendElement(document, traceForm, 'button', 'stopBtn', { textContent: 'Stop' });
-  const resetBtn = appendElement(document, traceForm, 'button', 'resetBtn', { textContent: 'Reset' });
+  const startBtn = appendElement(document, traceForm, 'button', 'startBtn', {
+    textContent: 'Start',
+    attributes: { 'data-i18n': 'action.start' }
+  });
+  const stopBtn = appendElement(document, traceForm, 'button', 'stopBtn', {
+    textContent: 'Stop',
+    attributes: { 'data-i18n': 'action.stop' }
+  });
+  const resetBtn = appendElement(document, traceForm, 'button', 'resetBtn', {
+    textContent: 'Reset',
+    attributes: { 'data-i18n': 'action.reset' }
+  });
   const settingBtn = appendElement(document, traceForm, 'button', 'settingBtn', {
     textContent: 'Settings',
     attributes: {
       'aria-controls': 'settingMenu',
-      'aria-expanded': 'false'
+      'aria-expanded': 'false',
+      'data-i18n': 'action.settings'
     }
   });
-  const shareBtn = appendElement(document, traceForm, 'button', 'shareBtn', { textContent: 'Copy Share Link' });
+  const shareBtn = appendElement(document, traceForm, 'button', 'shareBtn', {
+    textContent: 'Copy Share Link',
+    attributes: { 'data-i18n': 'action.share' }
+  });
 
   appendElement(document, traceForm, 'span', 'taskStatusBadge');
   appendElement(document, traceForm, 'p', 'taskStatusDetail');
@@ -452,10 +480,17 @@ function createBrowserHarness(options = {}) {
     attributes: { list: 'deviceOptions' }
   });
   appendElement(document, settingMenu, 'datalist', 'deviceOptions');
-  appendElement(document, settingMenu, 'span', 'dev-error-message');
+  appendElement(document, settingMenu, 'span', 'dev-error-message', {
+    attributes: { 'data-i18n': 'settings.device.error' }
+  });
   appendElement(document, settingMenu, 'input', 'dataProvider', { type: 'text', value: '' });
-  appendElement(document, settingMenu, 'span', 'dp-error-message');
-  appendElement(document, settingMenu, 'button', 'saveBtn', { textContent: 'Save Settings' });
+  appendElement(document, settingMenu, 'span', 'dp-error-message', {
+    attributes: { 'data-i18n': 'settings.dataProvider.error' }
+  });
+  appendElement(document, settingMenu, 'button', 'saveBtn', {
+    textContent: 'Save Settings',
+    attributes: { 'data-i18n': 'settings.save' }
+  });
 
   const ipSelector = appendElement(document, body, 'div', 'ipSelector');
   appendElement(document, ipSelector, 'h2', 'ipSelectorTitle');
@@ -477,7 +512,8 @@ function createBrowserHarness(options = {}) {
     Event: FakeEvent,
     fetch: options.fetch || createDefaultFetch(options.devices),
     io: {
-      connect() {
+      connect(uri, connectOptions) {
+        socketConnections.push({ uri, options: connectOptions });
         return socket;
       }
     }
@@ -495,6 +531,8 @@ function createBrowserHarness(options = {}) {
   windowObject.io = context.io;
   windowObject.nextTraceUIState = require(path.join(repoRoot, 'assets/js/ui-state.js'));
   windowObject.nextTraceMTRAgg = require(path.join(repoRoot, 'assets/js/mtr-agg.js'));
+  windowObject.nextTraceI18n = require(path.join(repoRoot, 'assets/js/i18n.js'));
+  windowObject.nextTracePaths = require(path.join(repoRoot, 'assets/js/paths.js'));
 
   loadScript('assets/js/main.js', context);
   loadScript('assets/js/settingsmenu.js', context);
@@ -505,10 +543,12 @@ function createBrowserHarness(options = {}) {
     window: windowObject,
     document,
     socket,
+    socketConnections,
     localStorage,
     clipboardWrites,
     elements: {
       params,
+      uiLanguage,
       ipVersion,
       protocol,
       startBtn,
@@ -538,6 +578,12 @@ function createBrowserHarness(options = {}) {
       saveBtn: document.getElementById('saveBtn'),
       noticeBanner: document.getElementById('noticeBanner'),
       taskStatusBadge: document.getElementById('taskStatusBadge'),
+      taskStatusDetail: document.getElementById('taskStatusDetail'),
+      targetSummary: document.getElementById('targetSummary'),
+      connectionSummary: document.getElementById('connectionSummary'),
+      resultStateTitle: document.getElementById('resultStateTitle'),
+      resultStateText: document.getElementById('resultStateText'),
+      resolveModeSummary: document.getElementById('resolveModeSummary'),
       settingsSummaryInline: document.getElementById('settingsSummaryInline'),
       output,
       tbody,

--- a/tests/browser-harness.cjs
+++ b/tests/browser-harness.cjs
@@ -432,17 +432,31 @@ function createBrowserHarness(options = {}) {
     attributes: { 'data-i18n': 'action.share' }
   });
 
-  appendElement(document, traceForm, 'span', 'taskStatusBadge');
-  appendElement(document, traceForm, 'p', 'taskStatusDetail');
-  appendElement(document, traceForm, 'span', 'targetSummary');
-  appendElement(document, traceForm, 'span', 'connectionSummary');
-  appendElement(document, traceForm, 'span', 'resolveModeSummary');
+  appendElement(document, traceForm, 'span', 'taskStatusBadge', {
+    attributes: { 'data-i18n': 'state.idle.label' }
+  });
+  appendElement(document, traceForm, 'p', 'taskStatusDetail', {
+    attributes: { 'data-i18n': 'state.idle.detail' }
+  });
+  appendElement(document, traceForm, 'span', 'targetSummary', {
+    attributes: { 'data-i18n': 'target.notSet' }
+  });
+  appendElement(document, traceForm, 'span', 'connectionSummary', {
+    attributes: { 'data-i18n': 'connection.connecting' }
+  });
+  appendElement(document, traceForm, 'span', 'resolveModeSummary', {
+    attributes: { 'data-i18n': 'summary.resolve.local' }
+  });
   appendElement(document, traceForm, 'span', 'settingsSummaryInline');
 
   appendElement(document, body, 'div', 'noticeBanner', { hidden: true });
   appendElement(document, body, 'section', 'resultEmptyState', { hidden: false });
-  appendElement(document, body, 'h2', 'resultStateTitle');
-  appendElement(document, body, 'p', 'resultStateText');
+  appendElement(document, body, 'h2', 'resultStateTitle', {
+    attributes: { 'data-i18n': 'empty.idle.title' }
+  });
+  appendElement(document, body, 'p', 'resultStateText', {
+    attributes: { 'data-i18n': 'empty.idle.description' }
+  });
 
   const output = appendElement(document, body, 'table', 'output');
   const tbody = appendElement(document, output, 'tbody', '');
@@ -464,7 +478,13 @@ function createBrowserHarness(options = {}) {
     attributes: { 'aria-hidden': 'true' },
     className: 'settings-drawer'
   });
-  appendElement(document, settingMenu, 'button', 'settingCloseBtn', { textContent: 'x' });
+  appendElement(document, settingMenu, 'h2', 'settingsDrawerTitle', {
+    attributes: { 'data-i18n': 'settings.title' }
+  });
+  appendElement(document, settingMenu, 'button', 'settingCloseBtn', {
+    textContent: 'x',
+    attributes: { 'data-i18n-aria-label': 'settings.close' }
+  });
   appendElement(document, settingMenu, 'select', 'language', { value: 'cn' });
   appendElement(document, settingMenu, 'input', 'localResolveCheckbox', { type: 'checkbox', checked: true });
   appendElement(document, settingMenu, 'input', 'intervalTimeRange', { type: 'range', value: '0.040' });
@@ -477,13 +497,20 @@ function createBrowserHarness(options = {}) {
   appendElement(document, settingMenu, 'input', 'devInput', {
     type: 'text',
     value: '',
-    attributes: { list: 'deviceOptions' }
+    attributes: {
+      list: 'deviceOptions',
+      'data-i18n-placeholder': 'settings.device.placeholder'
+    }
   });
   appendElement(document, settingMenu, 'datalist', 'deviceOptions');
   appendElement(document, settingMenu, 'span', 'dev-error-message', {
     attributes: { 'data-i18n': 'settings.device.error' }
   });
-  appendElement(document, settingMenu, 'input', 'dataProvider', { type: 'text', value: '' });
+  appendElement(document, settingMenu, 'input', 'dataProvider', {
+    type: 'text',
+    value: '',
+    attributes: { 'data-i18n-placeholder': 'settings.dataProvider.placeholder' }
+  });
   appendElement(document, settingMenu, 'span', 'dp-error-message', {
     attributes: { 'data-i18n': 'settings.dataProvider.error' }
   });
@@ -493,8 +520,13 @@ function createBrowserHarness(options = {}) {
   });
 
   const ipSelector = appendElement(document, body, 'div', 'ipSelector');
-  appendElement(document, ipSelector, 'h2', 'ipSelectorTitle');
-  appendElement(document, ipSelector, 'button', 'ipSelectorClose', { textContent: 'Close' });
+  appendElement(document, ipSelector, 'h2', 'ipSelectorTitle', {
+    attributes: { 'data-i18n': 'modal.ipSelector.title' }
+  });
+  appendElement(document, ipSelector, 'button', 'ipSelectorClose', {
+    textContent: 'Close',
+    attributes: { 'data-i18n-aria-label': 'modal.close' }
+  });
   appendElement(document, ipSelector, 'div', 'ip-list');
 
   const context = {

--- a/tests/i18n.test.cjs
+++ b/tests/i18n.test.cjs
@@ -1,0 +1,261 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  DEFAULT_LOCALE,
+  SUPPORTED_LOCALES,
+  SUPPORTED_PREFERENCES,
+  TABLE_HEADER_KEYS,
+  applyDocumentTranslations,
+  createTranslator,
+  detectLocale,
+  getDictionary,
+  getHtmlLang,
+  getTableHeaderLabels,
+  listKeys,
+  normalizeLocale,
+  normalizePreference,
+  translate,
+} = require('../assets/js/i18n.js');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function createStubElement(attributes) {
+  return {
+    attributes: Object.assign({}, attributes),
+    textContent: '',
+    getAttribute(name) {
+      return this.attributes[name];
+    },
+    setAttribute(name, value) {
+      this.attributes[name] = value;
+    }
+  };
+}
+
+function createStubDocument(elements) {
+  return {
+    documentElement: createStubElement({}),
+    querySelectorAll(selector) {
+      const attribute = selector.slice(1, -1);
+      return elements.filter((element) =>
+        Object.prototype.hasOwnProperty.call(element.attributes, attribute));
+    }
+  };
+}
+
+function collectTemplateKeys() {
+  const html = fs.readFileSync(path.join(repoRoot, 'templates/index.html'), 'utf8');
+  const pattern = /data-i18n(?:-placeholder|-aria-label|-title)?="([^"]+)"/g;
+  const keys = new Set();
+  let match = pattern.exec(html);
+
+  while (match !== null) {
+    keys.add(match[1]);
+    match = pattern.exec(html);
+  }
+
+  return keys;
+}
+
+test('supported locales and preferences stay in sync', () => {
+  assert.deepEqual(SUPPORTED_LOCALES, ['en', 'zh']);
+  assert.deepEqual(SUPPORTED_PREFERENCES, ['auto', 'en', 'zh']);
+  assert.equal(DEFAULT_LOCALE, 'en');
+});
+
+test('locale dictionaries define exactly the same keys', () => {
+  const englishKeys = listKeys('en').slice().sort();
+  const chineseKeys = listKeys('zh').slice().sort();
+
+  assert.deepEqual(chineseKeys, englishKeys);
+});
+
+test('no dictionary entry is blank', () => {
+  SUPPORTED_LOCALES.forEach((locale) => {
+    const dictionary = getDictionary(locale);
+    Object.keys(dictionary).forEach((key) => {
+      assert.equal(typeof dictionary[key], 'string', `${locale}.${key} must be a string`);
+      assert.notEqual(dictionary[key].trim(), '', `${locale}.${key} must not be blank`);
+    });
+  });
+});
+
+test('normalizeLocale accepts browser tags and the legacy cn value', () => {
+  assert.equal(normalizeLocale('cn'), 'zh');
+  assert.equal(normalizeLocale('zh'), 'zh');
+  assert.equal(normalizeLocale('zh-Hans-CN'), 'zh');
+  assert.equal(normalizeLocale('EN'), 'en');
+  assert.equal(normalizeLocale('en_GB'), 'en');
+  assert.equal(normalizeLocale('de-DE'), null);
+  assert.equal(normalizeLocale(''), null);
+  assert.equal(normalizeLocale(42), null);
+});
+
+test('normalizePreference defaults to auto for unknown or missing values', () => {
+  assert.equal(normalizePreference('auto'), 'auto');
+  assert.equal(normalizePreference('AUTO'), 'auto');
+  assert.equal(normalizePreference('zh-CN'), 'zh');
+  assert.equal(normalizePreference('en'), 'en');
+  assert.equal(normalizePreference('de'), 'auto');
+  assert.equal(normalizePreference(null), 'auto');
+  assert.equal(normalizePreference(undefined), 'auto');
+});
+
+test('detectLocale honours an explicit preference before browser languages', () => {
+  assert.equal(detectLocale('zh', ['en-US']), 'zh');
+  assert.equal(detectLocale('en', ['zh-CN']), 'en');
+});
+
+test('detectLocale follows the browser when the preference is auto', () => {
+  assert.equal(detectLocale('auto', ['zh-CN', 'en-US']), 'zh');
+  assert.equal(detectLocale('auto', ['en-US', 'zh-CN']), 'en');
+  assert.equal(detectLocale(null, ['de-DE', 'zh-TW']), 'zh');
+  assert.equal(detectLocale('auto', 'zh-Hans'), 'zh');
+});
+
+test('detectLocale falls back to the default locale without usable candidates', () => {
+  assert.equal(detectLocale('auto', []), 'en');
+  assert.equal(detectLocale('auto', ['de-DE']), 'en');
+  assert.equal(detectLocale(undefined, undefined), 'en');
+});
+
+test('translate falls back to English and then to the raw key', () => {
+  assert.equal(translate('en', 'action.start'), 'Start');
+  assert.equal(translate('zh', 'action.start'), '开始');
+  assert.equal(translate('de', 'action.start'), 'Start');
+  assert.equal(translate('zh', 'missing.key'), 'missing.key');
+  assert.equal(translate('zh', ''), '');
+  assert.equal(translate('zh', null), '');
+});
+
+test('createTranslator binds a locale', () => {
+  assert.equal(createTranslator('zh')('action.stop'), '停止');
+  assert.equal(createTranslator('en')('action.stop'), 'Stop');
+});
+
+test('getHtmlLang maps locales to document language tags', () => {
+  assert.equal(getHtmlLang('en'), 'en');
+  assert.equal(getHtmlLang('zh'), 'zh-CN');
+  assert.equal(getHtmlLang('de'), 'en');
+});
+
+test('getTableHeaderLabels returns one label per column', () => {
+  assert.equal(TABLE_HEADER_KEYS.length, 13);
+  assert.equal(getTableHeaderLabels('en').length, TABLE_HEADER_KEYS.length);
+  assert.deepEqual(getTableHeaderLabels('en').slice(0, 3), ['HOP', 'IP', 'ASN']);
+  assert.deepEqual(getTableHeaderLabels('zh').slice(0, 3), ['跳数', 'IP', 'ASN']);
+});
+
+test('applyDocumentTranslations rewrites text, attributes, and the html lang', () => {
+  const button = createStubElement({ 'data-i18n': 'action.start' });
+  const input = createStubElement({ 'data-i18n-placeholder': 'form.target.placeholder' });
+  const closeButton = createStubElement({ 'data-i18n-aria-label': 'settings.close' });
+  const stubDocument = createStubDocument([button, input, closeButton]);
+
+  const appliedCount = applyDocumentTranslations(stubDocument, 'zh');
+
+  assert.equal(button.textContent, '开始');
+  assert.equal(input.getAttribute('placeholder'), 'IP / 域名 / URL');
+  assert.equal(closeButton.getAttribute('aria-label'), '关闭设置');
+  assert.equal(stubDocument.documentElement.getAttribute('lang'), 'zh-CN');
+  assert.equal(appliedCount, 3);
+});
+
+test('applyDocumentTranslations tolerates a missing document', () => {
+  assert.equal(applyDocumentTranslations(null, 'zh'), 0);
+  assert.equal(applyDocumentTranslations({}, 'zh'), 0);
+});
+
+test('every data-i18n key in the template exists in both dictionaries', () => {
+  const templateKeys = collectTemplateKeys();
+  const missing = [];
+
+  assert.ok(templateKeys.size >= 40, `expected an annotated template, found ${templateKeys.size} keys`);
+
+  SUPPORTED_LOCALES.forEach((locale) => {
+    const dictionary = getDictionary(locale);
+    templateKeys.forEach((key) => {
+      if (!Object.prototype.hasOwnProperty.call(dictionary, key)) {
+        missing.push(`${locale}: ${key}`);
+      }
+    });
+  });
+
+  assert.deepEqual(missing, []);
+});
+
+// The template scan below only covers data-i18n markup. These keys live in JS: main.js
+// passes them to t(), ui-state.js returns them bare. A typo in either renders the raw key.
+test('every translation key used by the browser scripts exists in the dictionaries', () => {
+  const dictionary = getDictionary('en');
+  const namespaces = Array.from(new Set(listKeys('en').map((key) => key.split('.')[0])));
+  const namespacePattern = new RegExp(`'((?:${namespaces.join('|')})\\.[A-Za-z0-9_.]+)'`, 'g');
+  const unknown = [];
+  let inspectedCount = 0;
+
+  ['assets/js/main.js', 'assets/js/ui-state.js', 'assets/js/settingsmenu.js'].forEach((relativePath) => {
+    const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+    [/\bt\('([^']*)'\)/g, namespacePattern].forEach((pattern) => {
+      pattern.lastIndex = 0;
+      let match = pattern.exec(source);
+      while (match !== null) {
+        inspectedCount += 1;
+        if (!Object.prototype.hasOwnProperty.call(dictionary, match[1])) {
+          unknown.push(`${relativePath}: ${match[1]}`);
+        }
+        match = pattern.exec(source);
+      }
+    });
+  });
+
+  assert.ok(inspectedCount >= 30, `expected to find the in-script keys, inspected ${inspectedCount}`);
+  assert.deepEqual(unknown, []);
+});
+
+test('every backend error code is either localized or deliberately passed through', () => {
+  const appSource = fs.readFileSync(path.join(repoRoot, 'app.py'), 'utf8');
+  const codePattern = /(?:PayloadError\(\s*|emit_error\(\s*|emit_nexttrace_error\([^,]+,\s*)"([a-z_]+)"/g;
+  const codes = new Set();
+  let match = codePattern.exec(appSource);
+
+  while (match !== null) {
+    codes.add(match[1]);
+    match = codePattern.exec(appSource);
+  }
+
+  // These two put nexttrace's own stdout/stderr in `message`; translating them would
+  // discard the diagnostic, so main.js shows them verbatim on purpose.
+  const passthroughCodes = new Set(['nexttrace_exit_nonzero', 'nexttrace_invalid_args']);
+  const dictionary = getDictionary('en');
+
+  assert.ok(codes.size >= 8, `expected to find the backend error codes, found ${codes.size}`);
+
+  const unhandled = Array.from(codes).filter((code) =>
+    !passthroughCodes.has(code) &&
+    !Object.prototype.hasOwnProperty.call(dictionary, `serverError.${code}`)).sort();
+
+  assert.deepEqual(unhandled, []);
+});
+
+test('the template ships the English copy that matches the dictionary defaults', () => {
+  const html = fs.readFileSync(path.join(repoRoot, 'templates/index.html'), 'utf8');
+  const pattern = /data-i18n="([^"]+)"[^>]*>([^<]*)</g;
+  const dictionary = getDictionary('en');
+  const mismatched = [];
+  let match = pattern.exec(html);
+
+  while (match !== null) {
+    const key = match[1];
+    const markupCopy = match[2].trim();
+    if (markupCopy !== '' && dictionary[key] !== markupCopy) {
+      mismatched.push(`${key}: ${JSON.stringify(markupCopy)} != ${JSON.stringify(dictionary[key])}`);
+    }
+    match = pattern.exec(html);
+  }
+
+  assert.deepEqual(mismatched, []);
+});

--- a/tests/ui-state.test.cjs
+++ b/tests/ui-state.test.cjs
@@ -8,6 +8,7 @@ const {
   deriveEmptyState,
   deriveTaskMeta,
   formatTargetSummary,
+  getConnectionStatusKey,
   loadRecentQueries,
   upsertRecentQuery,
 } = require('../assets/js/ui-state.js');
@@ -39,32 +40,54 @@ test('deriveActionState enables stop during resolving and disables start while b
   assert.equal(disconnectedState.startDisabled, true);
 });
 
-test('deriveEmptyState returns waiting copy while the trace has no rows yet', () => {
+test('deriveEmptyState returns waiting copy keys while the trace has no rows yet', () => {
   const state = deriveEmptyState('waiting', 'connected', false);
   assert.equal(state.visible, true);
-  assert.equal(state.title, 'Waiting for first hop');
+  assert.equal(state.titleKey, 'empty.waiting.title');
+  assert.equal(state.descriptionKey, 'empty.waiting.description');
 });
 
-test('deriveTaskMeta surfaces retained-results copy for completed traces', () => {
+test('deriveTaskMeta surfaces retained-results copy keys for completed traces', () => {
   const meta = deriveTaskMeta('complete', 'connected', 3);
-  assert.equal(meta.label, 'Complete');
+  assert.equal(meta.labelKey, 'state.complete.label');
   assert.equal(meta.tone, 'success');
-  assert.match(meta.detail, /retained/i);
+  assert.equal(meta.detailKey, 'state.complete.detail');
+  assert.equal(deriveTaskMeta('complete', 'connected', 0).detailKey, 'state.complete.detailEmpty');
 });
 
 test('formatTargetSummary shows resolved targets when local resolve changes the value', () => {
   assert.equal(formatTargetSummary('example.com', '1.1.1.1'), 'example.com -> 1.1.1.1');
-  assert.equal(formatTargetSummary('', ''), 'Not set');
+  assert.equal(formatTargetSummary('', ''), 'target.notSet');
+  assert.equal(formatTargetSummary('', '', () => '未设置'), '未设置');
 });
 
 test('buildSettingsSummary emits concise status chips', () => {
-  const summary = buildSettingsSummary({
+  const settings = {
     language: 'en',
     intervalSeconds: '0.04',
     packetSize: '128',
     dataProvider: 'LeoMoeAPI',
     localResolve: true
-  });
+  };
 
-  assert.deepEqual(summary, ['EN', 'Local Resolve', '40 ms', '128 B', 'LeoMoeAPI']);
+  assert.deepEqual(buildSettingsSummary(settings), [
+    'EN',
+    'summary.resolve.local',
+    '40 ms',
+    '128 B',
+    'LeoMoeAPI'
+  ]);
+  assert.deepEqual(buildSettingsSummary(settings, () => 'Local Resolve'), [
+    'EN',
+    'Local Resolve',
+    '40 ms',
+    '128 B',
+    'LeoMoeAPI'
+  ]);
+});
+
+test('getConnectionStatusKey maps every connection state to a copy key', () => {
+  assert.equal(getConnectionStatusKey('connected'), 'connection.connected');
+  assert.equal(getConnectionStatusKey('disconnected'), 'connection.disconnected');
+  assert.equal(getConnectionStatusKey('connecting'), 'connection.connecting');
 });


### PR DESCRIPTION
Interface language (English + Simplified Chinese):

- New assets/js/i18n.js holds both dictionaries, locale normalization, browser language detection and DOM application (data-i18n plus placeholder/aria-label /title variants).
- Header selector offers Auto, English and 中文. Auto is the default and follows the browser's Accept-Language; an explicit choice is stored in localStorage under uiLanguage. This is distinct from the pre-existing `language` setting, which is passed to the nexttrace CLI and controls geolocation data language.
- ui-state.js now returns translation keys (labelKey/detailKey/titleKey) instead of literal copy, so it stays dependency-free and pure; the render layer translates. mtr-agg.js accepts localized table header labels.
- The notice banner stores a key rather than translated text, so a notice raised in one language re-renders when the language changes. Server-supplied nexttrace diagnostics have no key and are shown verbatim.
- Backend error codes map to localized copy. A contract test extracts the codes from app.py and fails if a new one is neither localized nor explicitly passed through, so untranslated text cannot leak into the UI unnoticed.

Relative asset paths (enables sub-path deployment):

- Template references /assets/* as assets/*, and the stylesheet resolves its font as ../font/* relative to itself.
- New assets/js/paths.js derives the page's base directory so /api/devices and the Socket.IO path are built from it. The Socket.IO path matters most: its default is hardcoded in the client library and does not follow the document directory, so without this the page renders but never connects.
- README (both languages) documents the sub-path nginx recipe, including the $connection_upgrade map the snippet needs and the parent-directory resolution that makes the trailing-slash redirect necessary.

Tests: 49 unit tests and 14 browser control checks, all passing. New coverage resolves asset references through URL semantics rather than regex, checks every template and in-script translation key against both dictionaries, ties the test harness's hand-built DOM to the real template, and asserts script load order. Verified by mutation testing that each new check fails when its target breaks.

No backend changes: app.py, nexttrace_mtr.py, nginx.conf and the Dockerfile are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加中英文界面语言，支持自动/手动切换并保存偏好。
  * 支持子路径部署，自动适配资源、API、Socket.IO 与分享链接。
* **界面优化**
  * 优化窄屏页头和语言控件布局，表格表头随语言切换。
* **文档**
  * 补充界面语言及子路径部署配置说明。
* **测试**
  * 扩展国际化、路径解析与浏览器交互自动化校验。
* **构建与发布**
  * 强化脚本检查，改进镜像发布及镜像元数据标注。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->